### PR TITLE
Update PdfSharp.cs

### DIFF
--- a/PdfSharpCore/Pdf.IO/PdfReader.cs
+++ b/PdfSharpCore/Pdf.IO/PdfReader.cs
@@ -65,7 +65,7 @@ namespace PdfSharpCore.Pdf.IO
     {
         /// <summary>
         /// Determines whether the file specified by its path is a PDF file by inspecting the first eight
-        /// bytes of the data. If the file header has the form «%PDF-x.y» the function returns the version
+        /// bytes of the data. If the file header has the form Â«%PDF-x.yÂ» the function returns the version
         /// number as integer (e.g. 14 for PDF 1.4). If the file header is invalid or inaccessible
         /// for any reason, 0 is returned. The function never throws an exception. 
         /// </summary>
@@ -111,7 +111,7 @@ namespace PdfSharpCore.Pdf.IO
 
         /// <summary>
         /// Determines whether the specified stream is a PDF file by inspecting the first eight
-        /// bytes of the data. If the data begins with «%PDF-x.y» the function returns the version
+        /// bytes of the data. If the data begins with Â«%PDF-x.yÂ» the function returns the version
         /// number as integer (e.g. 14 for PDF 1.4). If the data is invalid or inaccessible
         /// for any reason, 0 is returned. The function never throws an exception. 
         /// </summary>
@@ -142,7 +142,7 @@ namespace PdfSharpCore.Pdf.IO
 
         /// <summary>
         /// Determines whether the specified data is a PDF file by inspecting the first eight
-        /// bytes of the data. If the data begins with «%PDF-x.y» the function returns the version
+        /// bytes of the data. If the data begins with Â«%PDF-x.yÂ» the function returns the version
         /// number as integer (e.g. 14 for PDF 1.4). If the data is invalid or inaccessible
         /// for any reason, 0 is returned. The function never throws an exception. 
         /// </summary>
@@ -158,8 +158,9 @@ namespace PdfSharpCore.Pdf.IO
         {
             try
             {
-                // Acrobat accepts headers like «%!PS-Adobe-N.n PDF-M.m»...
-                string header = PdfEncoders.RawEncoding.GetString(bytes, 0, bytes.Length);  // Encoding.ASCII.GetString(bytes);
+                // Acrobat accepts headers like Â«%!PS-Adobe-N.n PDF-M.mÂ»...
+                //string header = PdfEncoders.RawEncoding.GetString(bytes, 0, bytes.Length);  // Encoding.ASCII.GetString(bytes);
+                string header = Encoding.ASCII.GetString(bytes);
                 if (header[0] == '%' || header.IndexOf("%PDF", StringComparison.Ordinal) >= 0)
                 {
                     int ich = header.IndexOf("PDF-", StringComparison.Ordinal);


### PR DESCRIPTION
Comment current code at lines 162 and using back the code from the comment in that lines. 
Current code will return '0' and give an error 'The specified file has no valid PDF file header.' Using back original codes from PdfSharp will return pdf version.