### PR TITLE
Add Default Implementations for ImageSource and FontResolver to PdfSharpCore

### DIFF
--- a/PdfSharpCore/Drawing/ImageSource.cs
+++ b/PdfSharpCore/Drawing/ImageSource.cs
@@ -11,6 +11,10 @@ namespace MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes
 
     public abstract class ImageSource
     {
+        /// <summary>
+        /// Gets or sets the image source implemention to use for reading images.
+        /// </summary>
+        /// <value>The image source impl.</value>
         public static ImageSource ImageSourceImpl { get; set; }
 
         public interface IImageSource

--- a/PdfSharpCore/Drawing/XImage.cs
+++ b/PdfSharpCore/Drawing/XImage.cs
@@ -105,6 +105,7 @@ namespace PdfSharpCore.Drawing
 
         /// <summary>
         /// Creates an image from the specified file.
+        /// For non-pdf files, this requires that an instance of an implementation of <see cref="T:MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes.ImageSource"/> be set on the `ImageSource.ImageSourceImpl` property.
         /// </summary>
         /// <param name="path">The path to a BMP, PNG, GIF, JPEG, TIFF, or PDF file.</param>
         public static XImage FromFile(string path)
@@ -116,6 +117,7 @@ namespace PdfSharpCore.Drawing
 
         /// <summary>
         /// Creates an image from the specified stream.<br/>
+        /// For non-pdf files, this requires that an instance of an implementation of <see cref="T:MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes.ImageSource"/> be set on the `ImageSource.ImageSourceImpl` property.
         /// Silverlight supports PNG and JPEF only.
         /// </summary>
         /// <param name="stream">The stream containing a BMP, PNG, GIF, JPEG, TIFF, or PDF file.</param>

--- a/PdfSharpCore/Drawing/XImage.cs
+++ b/PdfSharpCore/Drawing/XImage.cs
@@ -34,6 +34,8 @@ using PdfSharpCore.Pdf.IO;
 using PdfSharpCore.Pdf.Advanced;
 using MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes;
 using static MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes.ImageSource;
+using PdfSharpCore.Utils;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace PdfSharpCore.Drawing
 {
@@ -76,6 +78,9 @@ namespace PdfSharpCore.Drawing
         // Useful stuff here: http://stackoverflow.com/questions/350027/setting-wpf-image-source-in-code
         XImage(string path)
         {
+#if NETCOREAPP1_1
+            if (ImageSource.ImageSourceImpl == null) ImageSource.ImageSourceImpl = new ImageSharpImageSource<Rgba32>();
+#endif
             _source = ImageSource.FromFile(path);
             Initialize();
         }
@@ -91,6 +96,9 @@ namespace PdfSharpCore.Drawing
         {
             // Create a dummy unique path.
             _path = "*" + Guid.NewGuid().ToString("B");
+#if NETCOREAPP1_1
+            if (ImageSource.ImageSourceImpl == null) ImageSource.ImageSourceImpl = new ImageSharpImageSource<Rgba32>();
+#endif
             _source = ImageSource.FromStream(_path, stream);
             Initialize();
         }
@@ -106,6 +114,7 @@ namespace PdfSharpCore.Drawing
         /// <summary>
         /// Creates an image from the specified file.
         /// For non-pdf files, this requires that an instance of an implementation of <see cref="T:MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes.ImageSource"/> be set on the `ImageSource.ImageSourceImpl` property.
+        /// For .NetCore apps, if this property is null at this point, then <see cref="T:PdfSharpCore.Utils.ImageSharpImageSource"/> with <see cref="T:SixLabors.ImageSharp.PixelFormats.Rgba32"/> Pixel Type is used
         /// </summary>
         /// <param name="path">The path to a BMP, PNG, GIF, JPEG, TIFF, or PDF file.</param>
         public static XImage FromFile(string path)
@@ -118,6 +127,7 @@ namespace PdfSharpCore.Drawing
         /// <summary>
         /// Creates an image from the specified stream.<br/>
         /// For non-pdf files, this requires that an instance of an implementation of <see cref="T:MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes.ImageSource"/> be set on the `ImageSource.ImageSourceImpl` property.
+        /// For .NetCore apps, if this property is null at this point, then <see cref="T:PdfSharpCore.Utils.ImageSharpImageSource"/> with <see cref="T:SixLabors.ImageSharp.PixelFormats.Rgba32"/> Pixel Type is used
         /// Silverlight supports PNG and JPEF only.
         /// </summary>
         /// <param name="stream">The stream containing a BMP, PNG, GIF, JPEG, TIFF, or PDF file.</param>

--- a/PdfSharpCore/Fonts/GlobalFontSettings.cs
+++ b/PdfSharpCore/Fonts/GlobalFontSettings.cs
@@ -1,4 +1,4 @@
-﻿#region PDFsharp - A .NET library for processing PDF
+#region PDFsharp - A .NET library for processing PDF
 //
 // Authors:
 //   Stefan Lange
@@ -45,7 +45,7 @@ namespace PdfSharpCore.Fonts
 
         /// <summary>
         /// Gets or sets the global font resolver for the current application domain.
-        /// This static function must be called only once and before any font operation was executed by PdfSharpCore.
+        /// This static property should be set only once and before any font operation was executed by PdfSharpCore.
         /// If this is not easily to obtain, e.g. because your code is running on a web server, you must provide the
         /// same instance of your font resolver in every subsequent setting of this property.
         /// In a web application set the font resolver in Global.asax.

--- a/PdfSharpCore/Fonts/GlobalFontSettings.cs
+++ b/PdfSharpCore/Fonts/GlobalFontSettings.cs
@@ -1,4 +1,4 @@
-#region PDFsharp - A .NET library for processing PDF
+﻿#region PDFsharp - A .NET library for processing PDF
 //
 // Authors:
 //   Stefan Lange
@@ -30,6 +30,7 @@
 using System;
 using PdfSharpCore.Internal;
 using PdfSharpCore.Pdf;
+using PdfSharpCore.Utils;
 
 namespace PdfSharpCore.Fonts
 {
@@ -49,10 +50,18 @@ namespace PdfSharpCore.Fonts
         /// If this is not easily to obtain, e.g. because your code is running on a web server, you must provide the
         /// same instance of your font resolver in every subsequent setting of this property.
         /// In a web application set the font resolver in Global.asax.
+        /// For .NetCore Apps, if a resolver is not set before the first get operation to this property,
+        /// the default Font resolver implementation: <see cref="T:PdfSharpCore.Utils.PdfSharpCore.Utils"/> is set and returned
         /// </summary>
         public static IFontResolver FontResolver
         {
-            get { return _fontResolver; }
+            get 
+            {
+#if NETCOREAPP1_1
+                if (_fontResolver == null) FontResolver = new FontResolver();
+#endif
+                return _fontResolver; 
+            }
             set
             {
                 // Cannot remove font resolver.

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -24,4 +24,7 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
     <DefineConstants>TRACE;RELEASE;NETCOREAPP1_1;PORTABLE</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0005" />
+  </ItemGroup>
 </Project>

--- a/PdfSharpCore/Utils/FontResolver.cs
+++ b/PdfSharpCore/Utils/FontResolver.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using PdfSharpCore.Fonts;
+
+namespace PdfSharpCore.Utils
+{
+    public class FontResolver : IFontResolver
+    {
+        public string DefaultFontName => "Calibri";
+
+        private static string[] s_SupportedFonts;
+
+        private readonly Dictionary<string, string> fontfamilyTofontfaceMap;
+        private static Dictionary<string, int> fontfaceTofontfileMap;
+
+        public FontResolver()
+        {
+            fontfamilyTofontfaceMap = new Dictionary<string, string>();
+        }
+
+        public static void SetupFontsFiles()
+        {
+            int numFonts = s_SupportedFonts.Length;
+            fontfaceTofontfileMap = new Dictionary<string, int>();
+
+            for (int i = 0; i < numFonts; ++i)
+                fontfaceTofontfileMap.Add(Path.GetFileName(s_SupportedFonts[i]), i);
+        }
+
+        static FontResolver()
+        {
+            bool isLinux = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux);
+            if (isLinux)
+            {
+                string fontDir = "/usr/share/fonts/truetype/";
+                s_SupportedFonts = Directory.GetFiles(fontDir, "*.ttf", SearchOption.AllDirectories);
+                SetupFontsFiles();
+                return;
+            }
+
+            bool isWindows = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
+            if (isWindows)
+            {
+                string fontDir = @"C:\Windows\Fonts";
+                s_SupportedFonts = Directory.GetFiles(fontDir, "*.ttf", SearchOption.AllDirectories);
+                SetupFontsFiles();
+                return;
+            }
+
+            throw new NotImplementedException("FontResolver not implemented for this platform.");
+        }
+
+        public byte[] GetFont(string faceName)
+        {
+            using (MemoryStream ms = new MemoryStream())
+            {
+                string ttfFile;
+
+                if (fontfaceTofontfileMap.TryGetValue(faceName, out int idx))
+                    ttfFile = s_SupportedFonts[idx];
+                else if (s_SupportedFonts.Length > 0)
+                    ttfFile = s_SupportedFonts[0];
+                else
+                    throw new System.Exception("No Font Files Found");
+
+                using (System.IO.FileStream ttf = System.IO.File.OpenRead(ttfFile))
+                {
+                    ttf.CopyTo(ms);
+                    ms.Position = 0;
+                    return ms.ToArray();
+                }
+            }
+        }
+
+        public FontResolverInfo ResolveTypeface(string familyName, bool isBold, bool isItalic)
+        {
+            string ttfFile = fontfaceTofontfileMap.Keys.First(),
+                tf, fontkey;
+
+            familyName = familyName.ToLower();
+
+            fontkey = familyName;
+            if (isBold) fontkey += "b";
+            if (isItalic) fontkey += "i";
+
+            if (!fontfamilyTofontfaceMap.TryGetValue(fontkey, out ttfFile))
+            {
+                foreach (string fontfile in fontfaceTofontfileMap.Keys)
+                {
+                    tf = Path.GetFileNameWithoutExtension(fontfile).ToLower().TrimEnd('-', '_');
+
+                    if (tf.Contains(familyName))
+                    {
+                        ttfFile = fontfile;
+
+                        if (isBold && isItalic)
+                        {
+                            if ((tf.Contains("bold") && tf.Contains("italic")) || (tf.EndsWith("bi", StringComparison.Ordinal) || tf.EndsWith("ib", StringComparison.Ordinal)))
+                            {
+                                ttfFile = fontfile;
+                                break;
+                            }
+                        }
+                        else if (isBold)
+                        {
+                            if (tf.Contains("bold") || tf.EndsWith("b", StringComparison.Ordinal) || tf.EndsWith("bi", StringComparison.Ordinal))
+                            {
+                                ttfFile = fontfile;
+                                break;
+                            }
+                        }
+                        else if (isItalic)
+                        {
+                            if (tf.Contains("italic") || tf.EndsWith("i", StringComparison.Ordinal) || tf.EndsWith("ib", StringComparison.Ordinal))
+                            {
+                                ttfFile = fontfile;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                fontfamilyTofontfaceMap.Add(fontkey, ttfFile);
+            }
+
+            if (ttfFile == null) ttfFile = fontfaceTofontfileMap.Keys.First();
+            return new FontResolverInfo(ttfFile);
+        }
+    }
+}

--- a/PdfSharpCore/Utils/ImageSharpImageSource.cs
+++ b/PdfSharpCore/Utils/ImageSharpImageSource.cs
@@ -1,0 +1,79 @@
+﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes;
+using System;
+using System.IO;
+using SixLabors.ImageSharp.Formats.Jpeg;
+
+namespace PdfSharpCore.Utils
+{
+    public class ImageSharpImageSource<TPixel> : ImageSource where TPixel : struct, IPixel<TPixel>
+    {
+        protected override IImageSource FromBinaryImpl(string name, Func<byte[]> imageSource, int? quality = 75)
+        {
+            return new ImageSharpImageSourceImpl<TPixel>(name, () =>
+            {
+                return Image.Load<TPixel>(imageSource.Invoke());
+            }, (int)quality);
+        }
+
+        protected override IImageSource FromFileImpl(string path, int? quality = 75)
+        {
+            return new ImageSharpImageSourceImpl<TPixel>(path, () =>
+            {
+                return Image.Load<TPixel>(path);
+            }, (int)quality);
+        }
+
+        protected override IImageSource FromStreamImpl(string name, Func<Stream> imageStream, int? quality = 75)
+        {
+            return new ImageSharpImageSourceImpl<TPixel>(name, () =>
+            {
+                using (var stream = imageStream.Invoke())
+                {
+                    return Image.Load<TPixel>(stream);
+                }
+            }, (int)quality);
+        }
+
+        private class ImageSharpImageSourceImpl<TPixel2> : IImageSource where TPixel2 : struct, IPixel<TPixel2>
+        {
+
+            private Image<TPixel2> _image;
+            private Image<TPixel2> Image
+            {
+                get
+                {
+                    if (_image == null)
+                    {
+                        _image = _getImage.Invoke();
+                    }
+                    return _image;
+                }
+            }
+            private Func<Image<TPixel2>> _getImage;
+            private readonly int _quality;
+
+            public int Width => Image.Width;
+            public int Height => Image.Height;
+            public string Name { get; }
+
+            public ImageSharpImageSourceImpl(string name, Func<Image<TPixel2>> getImage, int quality)
+            {
+                Name = name;
+                _getImage = getImage;
+                _quality = quality;
+            }
+
+            public void SaveAsJpeg(MemoryStream ms)
+            {
+                Image.SaveAsJpeg(ms, new JpegEncoder() { Quality = this._quality });
+            }
+
+            public void Dispose()
+            {
+                Image.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added Default Implementations for ImageSource and FontResolver to PdfSharpCore so these classes can be part of the nugget.

There had been a couple of issues (#18, #22) related to these classes being missing from the nugget.

I added implementations based largely on what already exist in other projects in this repository with some modifications.

I used these default implementations when none was explicitly provided. These can be extended or a completely different implementation can be set