### PR TITLE
Make font resolver better match unstyled fonts

### DIFF
--- a/PdfSharpCore/Utils/FontResolver.cs
+++ b/PdfSharpCore/Utils/FontResolver.cs
@@ -119,6 +119,12 @@ namespace PdfSharpCore.Utils
                                 break;
                             }
                         }
+                        else
+                        {
+                            //We found a match on this font and did not want bold or italic.
+                            //This is not guaranteed to always be correct, but the first matching key is usually the normal variant.
+                            break;
+                        }
                     }
                 }
 


### PR DESCRIPTION
This is just a short term fix to fix the case I ran into in https://github.com/ststeiger/PdfSharpCore/issues/30

When a font is requested as not bold and not italic, the last matching font through the loop is used. The regular one usually lands first before the variants, so short-circuit as soon as we hit a match.

Long term it might be better to use ImageSharp.Fonts but right now it doesn't look like they expose enough information on detected fonts to be able to give that to PdfSharp.