### PR TITLE
Support for PNG Transparency

### DIFF
--- a/PdfSharpCore/Drawing/ImageSource.cs
+++ b/PdfSharpCore/Drawing/ImageSource.cs
@@ -12,7 +12,7 @@ namespace MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes
     public abstract class ImageSource
     {
         /// <summary>
-        /// Gets or sets the image source implemention to use for reading images.
+        /// Gets or sets the image source implementation to use for reading images.
         /// </summary>
         /// <value>The image source impl.</value>
         public static ImageSource ImageSourceImpl { get; set; }
@@ -23,6 +23,8 @@ namespace MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes
             int Height { get; }
             string Name { get; }
             void SaveAsJpeg(MemoryStream ms);
+            bool Transparent { get; }
+            void SaveAsPdfBitmap(MemoryStream ms);
         }
 
         protected abstract IImageSource FromFileImpl(string path, int? quality = 75);

--- a/PdfSharpCore/Drawing/XImage.cs
+++ b/PdfSharpCore/Drawing/XImage.cs
@@ -178,7 +178,7 @@ namespace PdfSharpCore.Drawing
             if (_source != null)
             {
                 //We always get a jpeg from an image source
-                _format = XImageFormat.Jpeg;
+                _format = _source.Transparent ? XImageFormat.Png : XImageFormat.Jpeg;
             }
         }
 
@@ -200,6 +200,14 @@ namespace PdfSharpCore.Drawing
         {
             var ms = new MemoryStream();
             _source.SaveAsJpeg(ms);
+            ms.Position = 0;
+            return ms;
+        }
+
+        public MemoryStream AsBitmap()
+        {
+            var ms = new MemoryStream();
+            _source.SaveAsPdfBitmap(ms);
             ms.Position = 0;
             return ms;
         }

--- a/PdfSharpCore/Utils/ImageSharpImageSource.cs
+++ b/PdfSharpCore/Utils/ImageSharpImageSource.cs
@@ -1,9 +1,9 @@
-﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes;
 using System;
 using System.IO;
-using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Png;
@@ -14,88 +14,41 @@ namespace PdfSharpCore.Utils
     {
         protected override IImageSource FromBinaryImpl(string name, Func<byte[]> imageSource, int? quality = 75)
         {
-            return new ImageSharpImageSourceImpl<TPixel>(name, () =>
-            {
-                return Image.Load<TPixel>(imageSource.Invoke());
-            }, (int)quality);
+            var image = Image.Load<TPixel>(imageSource.Invoke(), out IImageFormat imgFormat);
+            return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
         }
 
         protected override IImageSource FromFileImpl(string path, int? quality = 75)
         {
-            return new ImageSharpImageSourceImpl<Rgba32>(path, () => { return Image.Load<Rgba32>(path); },
-                (int) quality);
+            var image = Image.Load<TPixel>(path, out IImageFormat imgFormat);
+            return new ImageSharpImageSourceImpl<TPixel>(path, image, (int) quality, imgFormat is PngFormat);
         }
 
         protected override IImageSource FromStreamImpl(string name, Func<Stream> imageStream, int? quality = 75)
         {
-            return new ImageSharpImageSourceImpl<TPixel>(name, () =>
+            using (var stream = imageStream.Invoke())
             {
-                using (var stream = imageStream.Invoke())
-                {
-                    return Image.Load<TPixel>(stream);
-                }
-            }, (int)quality);
+                var image = Image.Load<TPixel>(stream, out IImageFormat imgFormat);
+                return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
+            }
         }
 
         private class ImageSharpImageSourceImpl<TPixel2> : IImageSource where TPixel2 : struct, IPixel<TPixel2>
         {
-
-            private Image<TPixel2> _image;
-            private Image<TPixel2> Image
-            {
-                get
-                {
-                    if (_image == null)
-                    {
-                        _image = _getImage.Invoke();
-                    }
-                    return _image;
-                }
-            }
-            private Func<Image<TPixel2>> _getImage;
+            private Image<TPixel2> Image { get; }
             private readonly int _quality;
 
             public int Width => Image.Width;
             public int Height => Image.Height;
             public string Name { get; }
-            private bool? _transparent;
+            public bool Transparent { get; internal set; }
 
-            public bool Transparent
-            {
-                get
-                {
-                    if (_transparent == null)
-                    {
-                        _transparent = false;
-                        //Note: This is going to result in the image being loaded into memory
-                        //up front, because we need to know if it is transparent or not.
-                        //Previously the image wouldn't be loaded until it was used.
-                        //If this is a problem, we might want to use GetMetaData and change
-                        //how ImageSources are constructed.
-                        if (Image.PixelType.BitsPerPixel == 32)
-                        {
-                            //ImageSharp will create PngMetaData for any image type when calling
-                            //GetFormatMetaData even if it wasn't PNG.
-                            //To avoid generating extra metadata for non-PNG, check for 32-bit color.
-                            //This will not completely prevent extra metadata from being created for
-                            //images that are not PNG, but at least it avoids extra logic sometimes.
-                            PngMetaData pngMeta = _image.MetaData.GetFormatMetaData(PngFormat.Instance);
-                            if (pngMeta != null && (pngMeta.ColorType == PngColorType.RgbWithAlpha ||
-                                                    pngMeta.ColorType == PngColorType.GrayscaleWithAlpha))
-                            {
-                                _transparent = true;
-                            }
-                        }
-                    }
-                    return _transparent ?? false;
-                }
-            }
-
-            public ImageSharpImageSourceImpl(string name, Func<Image<TPixel2>> getImage, int quality)
+            public ImageSharpImageSourceImpl(string name, Image<TPixel2> image, int quality, bool isTransparent)
             {
                 Name = name;
-                _getImage = getImage;
+                Image = image;
                 _quality = quality;
+                Transparent = isTransparent;
             }
 
             public void SaveAsJpeg(MemoryStream ms)

--- a/PdfSharpCore/Utils/ImageSharpImageSource.cs
+++ b/PdfSharpCore/Utils/ImageSharpImageSource.cs
@@ -3,7 +3,10 @@ using SixLabors.ImageSharp.PixelFormats;
 using MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes;
 using System;
 using System.IO;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Png;
 
 namespace PdfSharpCore.Utils
 {
@@ -19,10 +22,8 @@ namespace PdfSharpCore.Utils
 
         protected override IImageSource FromFileImpl(string path, int? quality = 75)
         {
-            return new ImageSharpImageSourceImpl<TPixel>(path, () =>
-            {
-                return Image.Load<TPixel>(path);
-            }, (int)quality);
+            return new ImageSharpImageSourceImpl<Rgba32>(path, () => { return Image.Load<Rgba32>(path); },
+                (int) quality);
         }
 
         protected override IImageSource FromStreamImpl(string name, Func<Stream> imageStream, int? quality = 75)
@@ -57,6 +58,38 @@ namespace PdfSharpCore.Utils
             public int Width => Image.Width;
             public int Height => Image.Height;
             public string Name { get; }
+            private bool? _transparent;
+
+            public bool Transparent
+            {
+                get
+                {
+                    if (_transparent == null)
+                    {
+                        _transparent = false;
+                        //Note: This is going to result in the image being loaded into memory
+                        //up front, because we need to know if it is transparent or not.
+                        //Previously the image wouldn't be loaded until it was used.
+                        //If this is a problem, we might want to use GetMetaData and change
+                        //how ImageSources are constructed.
+                        if (Image.PixelType.BitsPerPixel == 32)
+                        {
+                            //ImageSharp will create PngMetaData for any image type when calling
+                            //GetFormatMetaData even if it wasn't PNG.
+                            //To avoid generating extra metadata for non-PNG, check for 32-bit color.
+                            //This will not completely prevent extra metadata from being created for
+                            //images that are not PNG, but at least it avoids extra logic sometimes.
+                            PngMetaData pngMeta = _image.MetaData.GetFormatMetaData(PngFormat.Instance);
+                            if (pngMeta != null && (pngMeta.ColorType == PngColorType.RgbWithAlpha ||
+                                                    pngMeta.ColorType == PngColorType.GrayscaleWithAlpha))
+                            {
+                                _transparent = true;
+                            }
+                        }
+                    }
+                    return _transparent ?? false;
+                }
+            }
 
             public ImageSharpImageSourceImpl(string name, Func<Image<TPixel2>> getImage, int quality)
             {
@@ -73,6 +106,11 @@ namespace PdfSharpCore.Utils
             public void Dispose()
             {
                 Image.Dispose();
+            }
+            public void SaveAsPdfBitmap(MemoryStream ms)
+            {
+                BmpEncoder bmp = new BmpEncoder { BitsPerPixel = BmpBitsPerPixel.Pixel32 };
+                Image.Save(ms, bmp);
             }
         }
     }


### PR DESCRIPTION
This is not the best way to solve this, as we need to load the images to determine if they're transparent PNG prior to actually using them. We could use ReadMetaData to determine if they're transparent but that would require re-working the image source stuff to allow reading ahead of time without loading.

Also ignores all of the other supported formats that could have transparency, but it's clearer now how you can make that work.