### PR TITLE
* fix: handle more string tokens during parsing

### DIFF
--- a/PdfSharpCore/Pdf.IO/Parser.cs
+++ b/PdfSharpCore/Pdf.IO/Parser.cs
@@ -229,6 +229,9 @@ namespace PdfSharpCore.Pdf.IO
                     return pdfObject;
 
                 case Symbol.String:
+                case Symbol.UnicodeString:
+                case Symbol.HexString:
+                case Symbol.UnicodeHexString:
                     pdfObject = new PdfStringObject(_document, _lexer.Token);
                     pdfObject.SetObjectID(objectNumber, generationNumber);
                     if (!fromObjecStream)


### PR DESCRIPTION
The allows more types of PDF files to be loaded. [Same change is in the upstream PdfSharp](https://github.com/empira/PDFsharp/blob/3205bd933b464d150c0f42e8bcdff3314b6c6164/src/PdfSharp/Pdf.IO/Parser.cs#L237)