### PR TITLE
Fix for duplicate fonts

### DIFF
--- a/PdfSharpCore/Utils/FontResolver.cs
+++ b/PdfSharpCore/Utils/FontResolver.cs
@@ -26,7 +26,7 @@ namespace PdfSharpCore.Utils
             fontfaceTofontfileMap = new Dictionary<string, int>();
 
             for (int i = 0; i < numFonts; ++i)
-                fontfaceTofontfileMap.Add(Path.GetFileName(s_SupportedFonts[i]), i);
+                fontfaceTofontfileMap[Path.GetFileName(s_SupportedFonts[i])] = i;
         }
 
         static FontResolver()


### PR DESCRIPTION
Fix for when the same font exists in different packages, e.g. LiberationMono-Regular.ttf in fonts-liberation and fonts-liberation2

Add() throws an exception when a key already exists so use the Item[TKey] property instead which will overwrite the old value.