### PR TITLE
Fix for saving documents with a password

### DIFF
--- a/PdfSharpCore/Pdf/PdfDocument.cs
+++ b/PdfSharpCore/Pdf/PdfDocument.cs
@@ -376,7 +376,12 @@ namespace PdfSharpCore.Pdf
             {
                 // HACK: Remove XRefTrailer
                 if (_trailer is PdfCrossReferenceStream)
+                {
+                    // HACK^2: Preserve the SecurityHandler.
+                    PdfStandardSecurityHandler securityHandler = _securitySettings.SecurityHandler;
                     _trailer = new PdfTrailer((PdfCrossReferenceStream)_trailer);
+                    _trailer._securityHandler = securityHandler;
+                }
 
                 bool encrypt = _securitySettings.DocumentSecurityLevel != PdfDocumentSecurityLevel.None;
                 if (encrypt)


### PR DESCRIPTION
This fix is a port from empira/PDFsharp Changes for 1.50 beta 4:
https://github.com/empira/PDFsharp/commit/3768d5afe8b61c6c6c8d7df33c9b03dcd10ce06e#diff-1c9a89c56101e48a486c60530836a7d1