### PR TITLE
Allow uints(PdfUInteger) when calling ReadInt to support some encrypted file header reading

### DIFF
--- a/PdfSharpCore/Pdf/PdfDictionary.cs
+++ b/PdfSharpCore/Pdf/PdfDictionary.cs
@@ -407,6 +407,9 @@ namespace PdfSharpCore.Pdf
                 if (integerObject != null)
                     return integerObject.Value;
 
+                PdfUInteger uinteger = obj as PdfUInteger;
+                if (uinteger != null)
+                    return (int)uinteger.Value;
                 throw new InvalidCastException("GetInteger: Object is not an integer.");
             }
 


### PR DESCRIPTION
closes #58 
This allows reading of uints by ReadInt and converts them to negative integers. This allows for reading some headers with other encryption options, even if we don't support that encryption type (useful if pdf still has read access without). Should not break most existing code unless code expected an exception for reading uints and was catching it.


As a side note, I *think* this is the most up to date version of PdfSharp for .net standard/core.  Thanks for that.   The primary project seems fairly stale, so I may try to move some of the other PR on it over to this one.

As a minor side note, the published nuget library is a bit out of date so makes this library initially seem like it does not support WPF/non core based apps (despite the fact it is now on .net standard).

