### PR TITLE
Added support for custom font families which are not only bold or italic

### DIFF
--- a/MigraDocCore.DocumentObjectModel/MigraDocCore.DocumentObjectModel.csproj
+++ b/MigraDocCore.DocumentObjectModel/MigraDocCore.DocumentObjectModel.csproj
@@ -21,4 +21,7 @@
     <ProjectReference Include="..\PdfSharpCore\PdfSharpCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Remove="MigraDoc.DocumentObjectModel.Resources\AppResources.resx" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Custom fonts which contains more specified types where not correctly found.
Now you can specify a familyName (e.g. Lato Regular) an you will get the correct ttf file back.
The previous version does not found the following examples:
- Lato-BlackItalic.ttf
- Lato-Black.ttf
- Lato-BoldItalic.ttf
- Lato-Bold.ttf
- Lato-HairlineItalic.ttf
- Lato-Hairline.ttf
- Lato-HeavyItalic.ttf
- Lato-Heavy.ttf
- Lato-Italic.ttf
- Lato-LightItalic.ttf
- Lato-Light.ttf
- Lato-MediumItalic.ttf
- Lato-Medium.ttf
- Lato-Regular.ttf
- Lato-SemiboldItalic.ttf
- Lato-Semibold.ttf
- Lato-ThinItalic.ttf
- Lato-Thin.ttf