### PR TITLE
Fix Bold and Italic fonts being used when only Bold or only Italic specified

### DIFF
--- a/PdfSharpCore/Utils/FontResolver.cs
+++ b/PdfSharpCore/Utils/FontResolver.cs
@@ -114,7 +114,7 @@ namespace PdfSharpCore.Utils
                         }
                         else if (isBold)
                         {
-                            if (tf.Contains("bold") || tf.EndsWith("b", StringComparison.Ordinal) || tf.EndsWith("bd", StringComparison.Ordinal))
+                            if ((tf.Contains("bold") && !tf.Contains("italic")) || tf.EndsWith("b", StringComparison.Ordinal) || tf.EndsWith("bd", StringComparison.Ordinal))
                             {
                                 ttfFile = fontfile;
                                 break;
@@ -122,7 +122,7 @@ namespace PdfSharpCore.Utils
                         }
                         else if (isItalic)
                         {
-                            if (tf.Contains("italic") || tf.EndsWith("i", StringComparison.Ordinal) || tf.EndsWith("ib", StringComparison.Ordinal))
+                            if ((!tf.Contains("bold") && tf.Contains("italic")) || tf.EndsWith("i", StringComparison.Ordinal) || tf.EndsWith("ib", StringComparison.Ordinal))
                             {
                                 ttfFile = fontfile;
                                 break;


### PR DESCRIPTION
This fixes the scenario where your trying to write text with a Bold font but it uses Bold and Italic Instead. Same could happen witth Italic only as well.

My example was I was trying to write text with Arial Bold but it kept using Arial Bold Italic. This was due to it looping through the available .ttf files and it reached Arial_Bold_Italic.ttf before it got to arialbd.ttf or Arial_Bold.ttf. Since Arial_Bold_Italic.ttf has bold in the name it returned that font file.

I've added a check so that if you're trying to use Bold only, it doesn't contain Italic in the name as well.