### PR TITLE
FontResolver for cross-platform support. Fonts are grouped in families...

### DIFF
--- a/PdfSharpCore/Internal/FontFamilyModel.cs
+++ b/PdfSharpCore/Internal/FontFamilyModel.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using PdfSharpCore.Drawing;
+
+namespace PdfSharpCore.Internal
+{
+    public class FontFamilyModel
+    {
+        public string Name { get; set; }
+
+        public Dictionary<XFontStyle, string> FontFiles = new Dictionary<XFontStyle, string>();
+
+        public bool IsStyleAvailable(XFontStyle fontStyle)
+        {
+            return FontFiles.ContainsKey(fontStyle);
+        }
+    }
+}

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -25,6 +25,7 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta0009" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
   </ItemGroup>
 </Project>

--- a/PdfSharpCore/Utils/FontResolver.cs
+++ b/PdfSharpCore/Utils/FontResolver.cs
@@ -1,147 +1,219 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using PdfSharpCore.Drawing;
 using PdfSharpCore.Fonts;
+using PdfSharpCore.Internal;
+using SixLabors.Fonts;
 
 namespace PdfSharpCore.Utils
 {
     public class FontResolver : IFontResolver
     {
-        public string DefaultFontName => "Calibri";
+        public string DefaultFontName => "Arial";
 
-        private static string[] s_SupportedFonts;
+        private static readonly Dictionary<string, FontFamilyModel> InstalledFonts = new Dictionary<string, FontFamilyModel>();
 
-        private readonly Dictionary<string, string> fontfamilyTofontfaceMap;
-        private static Dictionary<string, int> fontfaceTofontfileMap;
+        private static readonly string[] SSupportedFonts;
 
         public FontResolver()
         {
-            fontfamilyTofontfaceMap = new Dictionary<string, string>();
-        }
-
-        public static void SetupFontsFiles()
-        {
-            int numFonts = s_SupportedFonts.Length;
-            fontfaceTofontfileMap = new Dictionary<string, int>();
-
-            for (int i = 0; i < numFonts; ++i)
-                fontfaceTofontfileMap[Path.GetFileName(s_SupportedFonts[i])] = i;
         }
 
         static FontResolver()
         {
+            string fontDir;
+
             bool isOSX = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX);
             if (isOSX)
             {
-                string fontDir = "/Library/Fonts/";
-                s_SupportedFonts = Directory.GetFiles(fontDir, "*.ttf", SearchOption.AllDirectories);
-                SetupFontsFiles();
+                fontDir = "/Library/Fonts/";
+                SSupportedFonts = Directory.GetFiles(fontDir, "*.ttf", SearchOption.AllDirectories);
+                SetupFontsFiles(SSupportedFonts);
                 return;
             }
-            
+
             bool isLinux = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux);
             if (isLinux)
             {
-                string fontDir = "/usr/share/fonts/truetype/";
-                s_SupportedFonts = Directory.GetFiles(fontDir, "*.ttf", SearchOption.AllDirectories);
-                SetupFontsFiles();
+                fontDir = "/usr/share/fonts/truetype/";
+                SSupportedFonts = Directory.GetFiles(fontDir, "*.ttf", SearchOption.AllDirectories);
+                SetupFontsFiles(SSupportedFonts);
                 return;
             }
-            
+
             bool isWindows = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
             if (isWindows)
             {
-                string fontDir = Environment.ExpandEnvironmentVariables(@"%SystemRoot%\Fonts");
-                s_SupportedFonts = Directory.GetFiles(fontDir, "*.ttf", SearchOption.AllDirectories);
-                SetupFontsFiles();
+                fontDir = Environment.ExpandEnvironmentVariables(@"%SystemRoot%\Fonts");
+                SSupportedFonts = Directory.GetFiles(fontDir, "*.ttf", SearchOption.AllDirectories);
+                SetupFontsFiles(SSupportedFonts);
                 return;
             }
-            
+
             throw new NotImplementedException("FontResolver not implemented for this platform (PdfSharpCore.Utils.FontResolver.cs).");
         }
 
-        public byte[] GetFont(string faceName)
+        public static void SetupFontsFiles(string[] sSupportedFonts)
+        {
+            // First group all fonts to font families
+            Dictionary<string, List<string>> tmpFontFamiliesTtfFilesDict = new Dictionary<string, List<string>>();
+            foreach (var fontPathFile in sSupportedFonts)
+            {
+                try
+                {
+                    FontDescription fontDescription = FontDescription.LoadDescription(fontPathFile);
+                    string fontFamilyName = fontDescription.FontFamily;
+                    Console.WriteLine(fontPathFile);
+
+                    if (tmpFontFamiliesTtfFilesDict.TryGetValue(fontFamilyName, out List<string> familyTtfFiles))
+                        familyTtfFiles.Add(fontPathFile);
+                    else
+                        tmpFontFamiliesTtfFilesDict.Add(fontFamilyName, new List<string> { fontPathFile });
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                }
+            }
+
+            // Deserialize all font families
+            foreach (var fontFamily in tmpFontFamiliesTtfFilesDict)
+                try
+                {
+                    InstalledFonts.Add(fontFamily.Key.ToLower(), DeserializeFontFamily(fontFamily));
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                }
+        }
+
+        [SuppressMessage("ReSharper", "PossibleMultipleEnumeration")]
+        private static FontFamilyModel DeserializeFontFamily(KeyValuePair<string, List<string>> fontFamily)
+        {
+            var font = new FontFamilyModel { Name = fontFamily.Key };
+
+            var fontList = fontFamily.Value;
+
+            // there is only one font
+            if (fontFamily.Value.Count == 1)
+            {
+                font.FontFiles.Add(XFontStyle.Regular, fontFamily.Value[0]);
+                return font;
+            }
+
+            // if element filenames have diff. lengths -> shortest name is regular
+            if (fontList.Any(e => e.Length != fontList[0].Length))
+            {
+                var orderedList = fontList.OrderBy(o => o.Length);
+                font.FontFiles.Add(XFontStyle.Regular, orderedList.First());
+
+                foreach (var elem in orderedList.Skip(1))
+                {
+                    var pair = DeserializeFontName(elem);
+                    if (!font.FontFiles.ContainsKey(pair.Key))
+                        font.FontFiles.Add(pair.Key, pair.Value);
+                }
+
+                return font;
+            }
+
+            // else
+            foreach (var elem in fontList)
+            {
+                var pair = DeserializeFontName(elem);
+                if (!font.FontFiles.ContainsKey(pair.Key))
+                    font.FontFiles.Add(pair.Key, pair.Value);
+            }
+            return font;
+        }
+
+        private static KeyValuePair<XFontStyle, string> DeserializeFontName(string fontFileName)
+        {
+
+            var tf = Path.GetFileNameWithoutExtension(fontFileName)?.ToLower().TrimEnd('-', '_');
+            if (tf == null)
+                return new KeyValuePair<XFontStyle, string>(XFontStyle.Regular, null);
+
+            // bold italic
+            if (tf.Contains("bold") && tf.Contains("italic") ||
+                tf.EndsWith("bi", StringComparison.Ordinal) ||
+                tf.EndsWith("ib", StringComparison.Ordinal) ||
+                tf.EndsWith("z", StringComparison.Ordinal))
+                return new KeyValuePair<XFontStyle, string>(XFontStyle.BoldItalic, fontFileName);
+            // bold
+            if (tf.Contains("bold") || tf.EndsWith("b", StringComparison.Ordinal) ||
+                tf.EndsWith("bd", StringComparison.Ordinal))
+                return new KeyValuePair<XFontStyle, string>(XFontStyle.Bold, fontFileName);
+            // italic
+            if (tf.Contains("italic") || tf.EndsWith("i", StringComparison.Ordinal) ||
+                tf.EndsWith("ib", StringComparison.Ordinal))
+                return new KeyValuePair<XFontStyle, string>(XFontStyle.Italic, fontFileName);
+
+            //We found a match on this font and did not want bold or italic.
+            //This is not guaranteed to always be correct, but the first matching key is usually the normal variant.
+            return new KeyValuePair<XFontStyle, string>(XFontStyle.Regular, fontFileName);
+        }
+
+
+        public byte[] GetFont(string faceFileName)
         {
             using (MemoryStream ms = new MemoryStream())
             {
-                string ttfFile;
-
-                if (fontfaceTofontfileMap.TryGetValue(faceName, out int idx))
-                    ttfFile = s_SupportedFonts[idx];
-                else if (s_SupportedFonts.Length > 0)
-                    ttfFile = s_SupportedFonts[0];
-                else
-                    throw new System.Exception("No Font Files Found");
-
-                using (System.IO.FileStream ttf = System.IO.File.OpenRead(ttfFile))
+                string ttfPathFile = "";
+                try
                 {
-                    ttf.CopyTo(ms);
-                    ms.Position = 0;
-                    return ms.ToArray();
+                    ttfPathFile = SSupportedFonts.ToList().First(x => x.ToLower().Contains(Path.GetFileName(faceFileName).ToLower()));
+                    using (var ttf = File.OpenRead(ttfPathFile))
+                    {
+                        ttf.CopyTo(ms);
+                        ms.Position = 0;
+                        return ms.ToArray();
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                    throw new Exception("No Font File Found - " + faceFileName + " - " + ttfPathFile);
                 }
             }
         }
 
         public FontResolverInfo ResolveTypeface(string familyName, bool isBold, bool isItalic)
         {
-            string ttfFile = fontfaceTofontfileMap.Keys.First(),
-                tf, fontkey;
+            if (InstalledFonts.Count == 0)
+                throw new FileNotFoundException("No Fonts installed on this device!");
 
-            familyName = familyName.ToLower();
+            string ttfFile = InstalledFonts.First().Value.FontFiles.First().Value;
 
-            fontkey = familyName;
-            if (isBold) fontkey += "b";
-            if (isItalic) fontkey += "i";
-
-            if (!fontfamilyTofontfaceMap.TryGetValue(fontkey, out ttfFile))
+            if (InstalledFonts.TryGetValue(familyName.ToLower(), out var family))
             {
-                foreach (string fontfile in fontfaceTofontfileMap.Keys)
+                if (isBold && isItalic)
                 {
-                    tf = Path.GetFileNameWithoutExtension(fontfile).ToLower().TrimEnd('-', '_');
-
-                    if (tf.Contains(familyName))
-                    {
-                        ttfFile = fontfile;
-
-                        if (isBold && isItalic)
-                        {
-                            if ((tf.Contains("bold") && tf.Contains("italic")) || (tf.EndsWith("bi", StringComparison.Ordinal) || tf.EndsWith("ib", StringComparison.Ordinal)))
-                            {
-                                ttfFile = fontfile;
-                                break;
-                            }
-                        }
-                        else if (isBold)
-                        {
-                            if ((tf.Contains("bold") && !tf.Contains("italic")) || tf.EndsWith("b", StringComparison.Ordinal) || tf.EndsWith("bd", StringComparison.Ordinal))
-                            {
-                                ttfFile = fontfile;
-                                break;
-                            }
-                        }
-                        else if (isItalic)
-                        {
-                            if ((!tf.Contains("bold") && tf.Contains("italic")) || tf.EndsWith("i", StringComparison.Ordinal) || tf.EndsWith("ib", StringComparison.Ordinal))
-                            {
-                                ttfFile = fontfile;
-                                break;
-                            }
-                        }
-                        else
-                        {
-                            //We found a match on this font and did not want bold or italic.
-                            //This is not guaranteed to always be correct, but the first matching key is usually the normal variant.
-                            break;
-                        }
-                    }
+                    if (family.FontFiles.TryGetValue(XFontStyle.BoldItalic, out ttfFile))
+                        return new FontResolverInfo(Path.GetFileName(ttfFile));
+                }
+                else if (isBold)
+                {
+                    if (family.FontFiles.TryGetValue(XFontStyle.Bold, out ttfFile))
+                        return new FontResolverInfo(Path.GetFileName(ttfFile));
+                }
+                else if (isItalic)
+                {
+                    if (family.FontFiles.TryGetValue(XFontStyle.Italic, out ttfFile))
+                        return new FontResolverInfo(Path.GetFileName(ttfFile));
                 }
 
-                fontfamilyTofontfaceMap.Add(fontkey, ttfFile);
+                if (family.FontFiles.TryGetValue(XFontStyle.Regular, out ttfFile))
+                    return new FontResolverInfo(Path.GetFileName(ttfFile));
+
+                return new FontResolverInfo(Path.GetFileName(family.FontFiles.First().Value));
             }
 
-            if (ttfFile == null) ttfFile = fontfaceTofontfileMap.Keys.First();
-            return new FontResolverInfo(ttfFile);
+            return new FontResolverInfo(Path.GetFileName(ttfFile));
         }
     }
 }


### PR DESCRIPTION
Now PdfSharpCore is able to deliver the right font for a requested FontFamily. 
With the help of SixLabors.Fonts, the FontFamiliy of every TTF file is determined and grouped.

Currently the current FontResolver tries to resolve the requested FontName by filename.
But for example: The font "Comic Sans MS, bold" has the filename comicz.ttf (Windows) and the filename "Comic Sans MS bold.ttf" (macOS), but both have the same FontFamilyName (Comic Sans MS).
With this commit, the user does not need to know the right filename, s/he only needs to know the right FontFamilyName.

This commit was successfully tested on: 
- .NetCore 2.2, Windows, Linux, macOS
- Xamarin.iOS