### PR TITLE
Implemented workaround to escape from the EOF infinite loop

### DIFF
--- a/PdfSharpCore/Pdf.IO/Parser.cs
+++ b/PdfSharpCore/Pdf.IO/Parser.cs
@@ -295,6 +295,10 @@ namespace PdfSharpCore.Pdf.IO
                 ReadSymbol(Symbol.EndStream);
                 symbol = ScanNextToken();
 #endif
+                if (symbol == Symbol.Eof)
+                {
+                    symbol = Symbol.EndObj;
+                }
             }
             if (!fromObjecStream && symbol != Symbol.EndObj)
                 ParserDiagnostics.ThrowParserException(PSSR.UnexpectedToken(_lexer.Token));
@@ -634,14 +638,14 @@ namespace PdfSharpCore.Pdf.IO
             {
                 Skip:
                 char ch = _lexer.MoveToNonWhiteSpace();
-                if (ch != 'e')
+                if (ch != 'e' && ch != Chars.EOF)
                 {
                     _lexer.ScanNextChar(false);
                     goto Skip;
                 }
             }
             Symbol current = _lexer.ScanNextToken();
-            if (symbol != current)
+            if (symbol != current && current != Symbol.Eof)
                 ParserDiagnostics.HandleUnexpectedToken(_lexer.Token);
             return current;
         }


### PR DESCRIPTION
Background to the Pull Request.

While processing sent Pdf we noticed that our service sporadically does not answer anymore. 
This was attributable to "PdfReader.Open". The process did not come back from this call.
During debugging, I saw that the "Parser" for this Pdf was caught in an infinite loop.
For reasons of data protection, however, I am not allowed to make the Pdf available for traceability purposes.
While testing I could not detect any side effects on other Pdf.  