### PR TITLE
Fix space width in XTextFormatter

### DIFF
--- a/PdfSharpCore/Drawing.Layout/XTextFormatter.cs
+++ b/PdfSharpCore/Drawing.Layout/XTextFormatter.cs
@@ -79,7 +79,7 @@ namespace PdfSharpCore.Drawing.Layout
                 _cyDescent = _lineSpace * _font.CellDescent / _font.CellSpace;
 
                 // HACK in XTextFormatter
-                _spaceWidth = _gfx.MeasureString("x x", value).Width;
+                _spaceWidth = _gfx.MeasureString("x x", value).Width;
                 _spaceWidth -= _gfx.MeasureString("xx", value).Width;
             }
         }


### PR DESCRIPTION
- replace unicode `replacement character` with an actual space.

If you open the XTextFormatter.cs raw file in a browser you will see the  `replacement character`:
![image](https://user-images.githubusercontent.com/6325279/80638902-1824aa80-8a59-11ea-94a4-525dd6d927c3.png)

This PR should fix issue https://github.com/ststeiger/PdfSharpCore/issues/78