### PR TITLE
Enhanced gradients

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "SixLabors/Fonts"]
+	path = SixLabors/Fonts
+	url = https://github.com/SixLabors/Fonts.git
+[submodule "SixLabors/Core"]
+	path = SixLabors/Core
+	url = https://github.com/SixLabors/Core.git
+[submodule "SixLabors/ImageSharp"]
+	path = SixLabors/ImageSharp
+	url = https://github.com/SixLabors/ImageSharp.git

--- a/PdfSharpCore/Drawing.Pdf/PdfGraphicsState.cs
+++ b/PdfSharpCore/Drawing.Pdf/PdfGraphicsState.cs
@@ -197,7 +197,11 @@ namespace PdfSharpCore.Drawing.Pdf
                 _realizedDashStyle = dashStyle;
             }
 
-            if (colorMode != PdfColorMode.Cmyk)
+            if (pen.Brush != null)
+            {
+                RealizeBrush(pen.Brush, colorMode, 0, 0, true);
+            }
+            else if (colorMode != PdfColorMode.Cmyk)
             {
                 if (_realizedStrokeColor.Rgb != color.Rgb)
                 {
@@ -235,7 +239,7 @@ namespace PdfSharpCore.Drawing.Pdf
         XColor _realizedFillColor = XColor.Empty;
         bool _realizedNonStrokeOverPrint;
 
-        public void RealizeBrush(XBrush brush, PdfColorMode colorMode, int renderingMode, double fontEmSize)
+        public void RealizeBrush(XBrush brush, PdfColorMode colorMode, int renderingMode, double fontEmSize, bool isForPen = false)
         {
             // Rendering mode 2 is used for bold simulation.
             // Reference: TABLE 5.3  Text rendering modes / Page 402
@@ -273,9 +277,16 @@ namespace PdfSharpCore.Drawing.Pdf
                     PdfShadingPattern pattern = new PdfShadingPattern(_renderer.Owner);
                     pattern.SetupFromBrush(gradientBrush, matrix, _renderer);
                     string name = _renderer.Resources.AddPattern(pattern);
-                    _renderer.AppendFormatString("/Pattern cs\n", name);
-                    _renderer.AppendFormatString("{0} scn\n", name);
-
+                    if (isForPen)
+                    {
+                        _renderer.AppendFormatString("/Pattern CS\n", name);
+                        _renderer.AppendFormatString("{0} SCN\n", name);
+                    }
+                    else
+                    {
+                        _renderer.AppendFormatString("/Pattern cs\n", name);
+                        _renderer.AppendFormatString("{0} scn\n", name);
+                    }
                     // Invalidate fill color.
                     _realizedFillColor = XColor.Empty;
                 }

--- a/PdfSharpCore/Drawing.Pdf/PdfGraphicsState.cs
+++ b/PdfSharpCore/Drawing.Pdf/PdfGraphicsState.cs
@@ -265,8 +265,7 @@ namespace PdfSharpCore.Drawing.Pdf
                 if (renderingMode != 0)
                     throw new InvalidOperationException("Rendering modes other than 0 can only be used with solid color brushes.");
 
-                XLinearGradientBrush gradientBrush = brush as XLinearGradientBrush;
-                if (gradientBrush != null)
+                if (brush is XBaseGradientBrush gradientBrush)
                 {
                     Debug.Assert(UnrealizedCtm.IsIdentity, "Must realize ctm first.");
                     XMatrix matrix = _renderer.DefaultViewMatrix;
@@ -387,7 +386,7 @@ namespace PdfSharpCore.Drawing.Pdf
         public XPoint RealizedTextPosition;
 
         /// <summary>
-        /// Indicates that the text transformation matrix currently skews 20° to the right.
+        /// Indicates that the text transformation matrix currently skews 20? to the right.
         /// </summary>
         public bool ItalicSimulationOn;
 

--- a/PdfSharpCore/Drawing.Pdf/PdfGraphicsState.cs
+++ b/PdfSharpCore/Drawing.Pdf/PdfGraphicsState.cs
@@ -397,7 +397,7 @@ namespace PdfSharpCore.Drawing.Pdf
         public XPoint RealizedTextPosition;
 
         /// <summary>
-        /// Indicates that the text transformation matrix currently skews 20? to the right.
+        /// Indicates that the text transformation matrix currently skews 20° to the right.
         /// </summary>
         public bool ItalicSimulationOn;
 

--- a/PdfSharpCore/Drawing/XBaseGradientBrush.cs
+++ b/PdfSharpCore/Drawing/XBaseGradientBrush.cs
@@ -1,0 +1,179 @@
+﻿#region PDFsharp - A .NET library for processing PDF
+//
+// Authors:
+//   Ben Askren
+//
+// Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
+//
+// http://www.PdfSharpCore.com
+// http://sourceforge.net/projects/pdfsharp
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.ComponentModel;
+using PdfSharpCore.Internal;
+#if GDI
+using System.Drawing;
+using System.Drawing.Drawing2D;
+//using GdiLinearGradientBrush = System.Drawing.Drawing2D.LinearGradientBrush;
+#endif
+#if WPF
+using System.Windows;
+using System.Windows.Media;
+using SysPoint = System.Windows.Point;
+using SysSize = System.Windows.Size;
+using SysRect = System.Windows.Rect;
+using WpfBrush = System.Windows.Media.Brush;
+#endif
+#if UWP
+using Windows.UI;
+using Windows.UI.Xaml.Media;
+using Microsoft.Graphics.Canvas;
+using Microsoft.Graphics.Canvas.Brushes;
+#endif
+
+// ReSharper disable RedundantNameQualifier because it is required for hybrid build
+namespace PdfSharpCore.Drawing
+{
+    public class XBaseGradientBrush : XBrush
+    {
+        protected XBaseGradientBrush(XColor color1, XColor color2)
+        {
+            _color1 = color1;
+            _color2 = color2;
+
+        }
+
+        //private Blend _GetBlend();
+        //private ColorBlend _GetInterpolationColors();
+        //private XColor[] _GetLinearColors();
+        //private RectangleF _GetRectangle();
+        //private Matrix _GetTransform();
+        //private WrapMode _GetWrapMode();
+        //private void _SetBlend(Blend blend);
+        //private void _SetInterpolationColors(ColorBlend blend);
+        //private void _SetLinearColors(XColor color1, XColor color2);
+        //private void _SetTransform(Matrix matrix);
+        //private void _SetWrapMode(WrapMode wrapMode);
+
+        //public override object Clone();
+
+        /// <summary>
+        /// Gets or sets an XMatrix that defines a local geometric transform for this LinearGradientBrush.
+        /// </summary>
+        public XMatrix Transform
+        {
+            get { return _matrix; }
+            set { _matrix = value; }
+        }
+
+        /// <summary>
+        /// Translates the brush with the specified offset.
+        /// </summary>
+        public void TranslateTransform(double dx, double dy)
+        {
+            _matrix.TranslatePrepend(dx, dy);
+        }
+
+        /// <summary>
+        /// Translates the brush with the specified offset.
+        /// </summary>
+        public void TranslateTransform(double dx, double dy, XMatrixOrder order)
+        {
+            _matrix.Translate(dx, dy, order);
+        }
+
+        /// <summary>
+        /// Scales the brush with the specified scalars.
+        /// </summary>
+        public void ScaleTransform(double sx, double sy)
+        {
+            _matrix.ScalePrepend(sx, sy);
+        }
+
+        /// <summary>
+        /// Scales the brush with the specified scalars.
+        /// </summary>
+        public void ScaleTransform(double sx, double sy, XMatrixOrder order)
+        {
+            _matrix.Scale(sx, sy, order);
+        }
+
+        /// <summary>
+        /// Rotates the brush with the specified angle.
+        /// </summary>
+        public void RotateTransform(double angle)
+        {
+            _matrix.RotatePrepend(angle);
+        }
+
+        /// <summary>
+        /// Rotates the brush with the specified angle.
+        /// </summary>
+        public void RotateTransform(double angle, XMatrixOrder order)
+        {
+            _matrix.Rotate(angle, order);
+        }
+
+        /// <summary>
+        /// Multiply the brush transformation matrix with the specified matrix.
+        /// </summary>
+        public void MultiplyTransform(XMatrix matrix)
+        {
+            _matrix.Prepend(matrix);
+        }
+
+        /// <summary>
+        /// Multiply the brush transformation matrix with the specified matrix.
+        /// </summary>
+        public void MultiplyTransform(XMatrix matrix, XMatrixOrder order)
+        {
+            _matrix.Multiply(matrix, order);
+        }
+
+        /// <summary>
+        /// Resets the brush transformation matrix with identity matrix.
+        /// </summary>
+        public void ResetTransform()
+        {
+            _matrix = new XMatrix();
+        }
+
+        //public void SetBlendTriangularShape(double focus);
+        //public void SetBlendTriangularShape(double focus, double scale);
+        //public void SetSigmaBellShape(double focus);
+        //public void SetSigmaBellShape(double focus, double scale);
+
+
+
+        //public Blend Blend { get; set; }
+        //public bool GammaCorrection { get; set; }
+        //public ColorBlend InterpolationColors { get; set; }
+        //public XColor[] LinearColors { get; set; }
+        //public RectangleF Rectangle { get; }
+        //public WrapMode WrapMode { get; set; }
+        //private bool interpolationColorsWasSet;
+
+        internal XColor _color1, _color2;
+        internal XMatrix _matrix;
+
+    }
+}

--- a/PdfSharpCore/Drawing/XGraphicsPath.cs
+++ b/PdfSharpCore/Drawing/XGraphicsPath.cs
@@ -360,7 +360,7 @@ namespace PdfSharpCore.Drawing
 
 #if GDI
         /// <summary>
-        /// Adds a cubic B?zier curve to the current figure.
+        /// Adds a cubic Bézier curve to the current figure.
         /// </summary>
         public void AddBezier(System.Drawing.Point pt1, System.Drawing.Point pt2, System.Drawing.Point pt3, System.Drawing.Point pt4)
         {
@@ -370,7 +370,7 @@ namespace PdfSharpCore.Drawing
 
 #if WPF
         /// <summary>
-        /// Adds a cubic B?zier curve to the current figure.
+        /// Adds a cubic Bézier curve to the current figure.
         /// </summary>
         public void AddBezier(SysPoint pt1, SysPoint pt2, SysPoint pt3, SysPoint pt4)
         {
@@ -380,7 +380,7 @@ namespace PdfSharpCore.Drawing
 
 #if GDI
         /// <summary>
-        /// Adds a cubic B?zier curve to the current figure.
+        /// Adds a cubic Bézier curve to the current figure.
         /// </summary>
         public void AddBezier(PointF pt1, PointF pt2, PointF pt3, PointF pt4)
         {
@@ -389,7 +389,7 @@ namespace PdfSharpCore.Drawing
 #endif
 
         /// <summary>
-        /// Adds a cubic BÈzier curve to the current figure.
+        /// Adds a cubic Bézier curve to the current figure.
         /// </summary>
         public void AddBezier(XPoint pt1, XPoint pt2, XPoint pt3, XPoint pt4)
         {
@@ -397,7 +397,7 @@ namespace PdfSharpCore.Drawing
         }
 
         /// <summary>
-        /// Adds a cubic BÈzier curve to the current figure.
+        /// Adds a cubic Bézier curve to the current figure.
         /// </summary>
         public void AddBezier(double x1, double y1, double x2, double y2, double x3, double y3, double x4, double y4)
         {
@@ -451,7 +451,7 @@ namespace PdfSharpCore.Drawing
 
 #if GDI
         /// <summary>
-        /// Adds a sequence of connected cubic BÈzier curves to the current figure.
+        /// Adds a sequence of connected cubic Bézier curves to the current figure.
         /// </summary>
         public void AddBeziers(System.Drawing.Point[] points)
         {
@@ -461,7 +461,7 @@ namespace PdfSharpCore.Drawing
 
 #if WPF
         /// <summary>
-        /// Adds a sequence of connected cubic BÈzier curves to the current figure.
+        /// Adds a sequence of connected cubic Bézier curves to the current figure.
         /// </summary>
         public void AddBeziers(SysPoint[] points)
         {
@@ -471,7 +471,7 @@ namespace PdfSharpCore.Drawing
 
 #if GDI
         /// <summary>
-        /// Adds a sequence of connected cubic BÈzier curves to the current figure.
+        /// Adds a sequence of connected cubic Bézier curves to the current figure.
         /// </summary>
         public void AddBeziers(PointF[] points)
         {
@@ -480,7 +480,7 @@ namespace PdfSharpCore.Drawing
 #endif
 
         /// <summary>
-        /// Adds a sequence of connected cubic BÈzier curves to the current figure.
+        /// Adds a sequence of connected cubic Bézier curves to the current figure.
         /// </summary>
         public void AddBeziers(XPoint[] points)
         {

--- a/PdfSharpCore/Drawing/XGraphicsPath.cs
+++ b/PdfSharpCore/Drawing/XGraphicsPath.cs
@@ -220,6 +220,9 @@ namespace PdfSharpCore.Drawing
             AddLine(pt1.X, pt1.Y, pt2.X, pt2.Y);
         }
 
+        public void AddMove(double x1, double y1)
+            => _corePath.MoveTo(x1, y1);
+
         /// <summary>
         /// Adds  a line segment to current figure.
         /// </summary>
@@ -357,7 +360,7 @@ namespace PdfSharpCore.Drawing
 
 #if GDI
         /// <summary>
-        /// Adds a cubic Bézier curve to the current figure.
+        /// Adds a cubic B?zier curve to the current figure.
         /// </summary>
         public void AddBezier(System.Drawing.Point pt1, System.Drawing.Point pt2, System.Drawing.Point pt3, System.Drawing.Point pt4)
         {
@@ -367,7 +370,7 @@ namespace PdfSharpCore.Drawing
 
 #if WPF
         /// <summary>
-        /// Adds a cubic Bézier curve to the current figure.
+        /// Adds a cubic B?zier curve to the current figure.
         /// </summary>
         public void AddBezier(SysPoint pt1, SysPoint pt2, SysPoint pt3, SysPoint pt4)
         {
@@ -377,7 +380,7 @@ namespace PdfSharpCore.Drawing
 
 #if GDI
         /// <summary>
-        /// Adds a cubic Bézier curve to the current figure.
+        /// Adds a cubic B?zier curve to the current figure.
         /// </summary>
         public void AddBezier(PointF pt1, PointF pt2, PointF pt3, PointF pt4)
         {
@@ -386,7 +389,7 @@ namespace PdfSharpCore.Drawing
 #endif
 
         /// <summary>
-        /// Adds a cubic Bézier curve to the current figure.
+        /// Adds a cubic BÃˆzier curve to the current figure.
         /// </summary>
         public void AddBezier(XPoint pt1, XPoint pt2, XPoint pt3, XPoint pt4)
         {
@@ -394,7 +397,7 @@ namespace PdfSharpCore.Drawing
         }
 
         /// <summary>
-        /// Adds a cubic Bézier curve to the current figure.
+        /// Adds a cubic BÃˆzier curve to the current figure.
         /// </summary>
         public void AddBezier(double x1, double y1, double x2, double y2, double x3, double y3, double x4, double y4)
         {
@@ -448,7 +451,7 @@ namespace PdfSharpCore.Drawing
 
 #if GDI
         /// <summary>
-        /// Adds a sequence of connected cubic Bézier curves to the current figure.
+        /// Adds a sequence of connected cubic BÃˆzier curves to the current figure.
         /// </summary>
         public void AddBeziers(System.Drawing.Point[] points)
         {
@@ -458,7 +461,7 @@ namespace PdfSharpCore.Drawing
 
 #if WPF
         /// <summary>
-        /// Adds a sequence of connected cubic Bézier curves to the current figure.
+        /// Adds a sequence of connected cubic BÃˆzier curves to the current figure.
         /// </summary>
         public void AddBeziers(SysPoint[] points)
         {
@@ -468,7 +471,7 @@ namespace PdfSharpCore.Drawing
 
 #if GDI
         /// <summary>
-        /// Adds a sequence of connected cubic Bézier curves to the current figure.
+        /// Adds a sequence of connected cubic BÃˆzier curves to the current figure.
         /// </summary>
         public void AddBeziers(PointF[] points)
         {
@@ -477,7 +480,7 @@ namespace PdfSharpCore.Drawing
 #endif
 
         /// <summary>
-        /// Adds a sequence of connected cubic Bézier curves to the current figure.
+        /// Adds a sequence of connected cubic BÃˆzier curves to the current figure.
         /// </summary>
         public void AddBeziers(XPoint[] points)
         {

--- a/PdfSharpCore/Drawing/XPen.cs
+++ b/PdfSharpCore/Drawing/XPen.cs
@@ -77,6 +77,30 @@ namespace PdfSharpCore.Drawing
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="XPen"/> class
+        /// </summary>
+        /// <param name="brush"></param>
+        public XPen(XBrush brush) : this(brush, 1, false) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XPen"/> class
+        /// </summary>
+        /// <param name="brush"></param>
+        /// <param name="width"></param>
+        public XPen(XBrush brush, double width) : this(brush, width, false) { }
+
+        internal XPen(XBrush brush, double width, bool immutable)
+        {
+            _brush = brush;
+            _width = width;
+            _lineJoin = XLineJoin.Miter;
+            _lineCap = XLineCap.Flat;
+            _dashStyle = XDashStyle.Solid;
+            _dashOffset = 0f;
+            _immutable = immutable;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="XPen"/> class.
         /// </summary>
         public XPen(XPen pen)
@@ -100,6 +124,20 @@ namespace PdfSharpCore.Drawing
             return new XPen(this);
         }
 
+        public XBrush Brush
+        {
+            get => _brush;
+            set
+            {
+                if (_immutable)
+                    throw new ArgumentException(PSSR.CannotChangeImmutableObject("XPen"));
+                _dirty = _dirty || _brush != value;
+                _brush = value;
+                _color = XColor.Empty;
+            }
+        }
+        internal XBrush _brush;
+
         /// <summary>
         /// Gets or sets the color.
         /// </summary>
@@ -112,6 +150,7 @@ namespace PdfSharpCore.Drawing
                     throw new ArgumentException(PSSR.CannotChangeImmutableObject("XPen"));
                 _dirty = _dirty || _color != value;
                 _color = value;
+                _brush = null;
             }
         }
         internal XColor _color;

--- a/PdfSharpCore/Drawing/XRadialGradientBrush.cs
+++ b/PdfSharpCore/Drawing/XRadialGradientBrush.cs
@@ -1,7 +1,7 @@
 #region PDFsharp - A .NET library for processing PDF
 //
 // Authors:
-//   Stefan Lange
+//   Ben Askren
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
@@ -33,7 +33,7 @@ using PdfSharpCore.Internal;
 #if GDI
 using System.Drawing;
 using System.Drawing.Drawing2D;
-using GdiLinearGradientBrush =System.Drawing.Drawing2D.LinearGradientBrush;
+//using GdiLinearGradientBrush = System.Drawing.Drawing2D.LinearGradientBrush;
 #endif
 #if WPF
 using System.Windows;
@@ -57,93 +57,58 @@ namespace PdfSharpCore.Drawing
     /// <summary>
     /// Defines a Brush with a linear gradient.
     /// </summary>
-    public sealed class XLinearGradientBrush : XBaseGradientBrush
+    public sealed class XRadialGradientBrush : XBaseGradientBrush
     {
-        //internal XLinearGradientBrush();
+        //internal XRadialGradientBrush();
 
 #if GDI
         /// <summary>
-        /// Initializes a new instance of the <see cref="XLinearGradientBrush"/> class.
+        /// Initializes a new instance of the <see cref="XRadialGradientBrush"/> class.
         /// </summary>
-        public XLinearGradientBrush(System.Drawing.Point point1, System.Drawing.Point point2, XColor color1, XColor color2)
-            : this(new XPoint(point1), new XPoint(point2), color1, color2)
+        public XRadialGradientBrush(System.Drawing.Point center1, System.Drawing.Point center2, double r1, double r2, XColor color1, XColor color2)
+            : this(new XPoint(center1), new XPoint(center2), r1, r2, color1, color2)
         { }
 #endif
 
 #if WPF
         /// <summary>
-        /// Initializes a new instance of the <see cref="XLinearGradientBrush"/> class.
+        /// Initializes a new instance of the <see cref="XRadialGradientBrush"/> class.
         /// </summary>
-        public XLinearGradientBrush(SysPoint point1, SysPoint point2, XColor color1, XColor color2)
-            : this(new XPoint(point1), new XPoint(point2), color1, color2)
+        public XRadialGradientBrush(SysPoint center1, SysPoint center2, double r1, double r2, XColor color1, XColor color2)
+            : this(new XPoint(center1), mew XPoint(center2), r1, r2, color1, color2)
         { }
 #endif
 
 #if GDI
         /// <summary>
-        /// Initializes a new instance of the <see cref="XLinearGradientBrush"/> class.
+        /// Initializes a new instance of the <see cref="XRadialGradientBrush"/> class.
         /// </summary>
-        public XLinearGradientBrush(PointF point1, PointF point2, XColor color1, XColor color2)
-            : this(new XPoint(point1), new XPoint(point2), color1, color2)
+        public XRadialGradientBrush(PointF center1, PointF center2, double r1, double r2, XColor color1, XColor color2)
+            : this(new XPoint(center1), new XPoint(center2), r1, r2, color1, color2)
         { }
 #endif
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="XLinearGradientBrush"/> class.
+        /// Initializes a new instance of the <see cref="XRadialGradientBrush"/> class.
         /// </summary>
-        public XLinearGradientBrush(XPoint point1, XPoint point2, XColor color1, XColor color2) : base(color1, color2)
+        public XRadialGradientBrush(XPoint center1, XPoint center2, double r1, double r2, XColor color1, XColor color2) : base(color1, color2)
         {
-            _point1 = point1;
-            _point2 = point2;
+            _center1 = center1;
+            _center2 = center2;
+            _r1 = r1;
+            _r2 = r2;
         }
 
-#if GDI
         /// <summary>
-        /// Initializes a new instance of the <see cref="XLinearGradientBrush"/> class.
+        /// Initializes a new instance of the <see cref="XRadialGradientBrush"/> class.
         /// </summary>
-        public XLinearGradientBrush(Rectangle rect, XColor color1, XColor color2, XLinearGradientMode linearGradientMode)
-            : this(new XRect(rect), color1, color2, linearGradientMode)
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="XLinearGradientBrush"/> class.
-        /// </summary>
-        public XLinearGradientBrush(RectangleF rect, XColor color1, XColor color2, XLinearGradientMode linearGradientMode)
-            : this(new XRect(rect), color1, color2, linearGradientMode)
-        { }
-#endif
-
-#if WPF
-        /// <summary>
-        /// Initializes a new instance of the <see cref="XLinearGradientBrush"/> class.
-        /// </summary>
-        public XLinearGradientBrush(Rect rect, XColor color1, XColor color2, XLinearGradientMode linearGradientMode)
-            : this(new XRect(rect), color1, color2, linearGradientMode)
-        { }
-#endif
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="XLinearGradientBrush"/> class.
-        /// </summary>
-        public XLinearGradientBrush(XRect rect, XColor color1, XColor color2, XLinearGradientMode linearGradientMode) : base(color1, color2)
+        public XRadialGradientBrush(XPoint center, double r1, double r2, XColor color1, XColor color2) : base(color1, color2)
         {
-            if (!Enum.IsDefined(typeof(XLinearGradientMode), linearGradientMode))
-                throw new InvalidEnumArgumentException("linearGradientMode", (int)linearGradientMode, typeof(XLinearGradientMode));
-
-            if (rect.Width == 0 || rect.Height == 0)
-                throw new ArgumentException("Invalid rectangle.", "rect");
-
-            _useRect = true;
-            _rect = rect;
-            _linearGradientMode = linearGradientMode;
+            _center1 = center;
+            _center2 = center;
+            _r1 = r1;
+            _r2 = r2;
         }
-
-        // TODO: 
-        //public XLinearGradientBrush(Rectangle rect, XColor color1, XColor color2, double angle);
-        //public XLinearGradientBrush(RectangleF rect, XColor color1, XColor color2, double angle);
-        //public XLinearGradientBrush(Rectangle rect, XColor color1, XColor color2, double angle, bool isAngleScaleable);
-        //public XLinearGradientBrush(RectangleF rect, XColor color1, XColor color2, double angle, bool isAngleScaleable);
-        //public XLinearGradientBrush(RectangleF rect, XColor color1, XColor color2, double angle, bool isAngleScaleable);
 
 
 #if GDI
@@ -161,19 +126,34 @@ namespace PdfSharpCore.Drawing
             //}
 
             // TODO: use dirty to optimize code
-            GdiLinearGradientBrush brush;
+            PathGradientBrush brush;
             try
             {
                 Lock.EnterGdiPlus();
+
+                    GraphicsPath gp = new GraphicsPath();
+
+                    
+
+                    gp.AddEllipse();
+
+                    PathGradientBrush pgb = new PathGradientBrush(gp);
+
+                    pgb.CenterPoint = new PointF(label1.ClientRectangle.Width / 2, 
+                                                 label1.ClientRectangle.Height / 2);
+                    pgb.CenterColor = Color.White;
+                    pgb.SurroundingColors = new Color[] { Color.Red };
+
+
                 if (_useRect)
                 {
-                    brush = new GdiLinearGradientBrush(_rect.ToRectangleF(),
+                    brush = new PathGradientBrush(_rect.ToRectangleF(),
                         _color1.ToGdiColor(), _color2.ToGdiColor(), (LinearGradientMode)_linearGradientMode);
                 }
                 else
                 {
                     brush = new GdiLinearGradientBrush(
-                        _point1.ToPointF(), _point2.ToPointF(),
+                        _center.ToPointF(), _point2.ToPointF(),
                         _color1.ToGdiColor(), _color2.ToGdiColor());
                 }
                 if (!_matrix.IsIdentity)
@@ -228,9 +208,9 @@ namespace PdfSharpCore.Drawing
             else
             {
 #if !SILVERLIGHT
-                brush = new System.Windows.Media.LinearGradientBrush(_color1.ToWpfColor(), _color2.ToWpfColor(), _point1, _point2);
+                brush = new System.Windows.Media.LinearGradientBrush(_color1.ToWpfColor(), _color2.ToWpfColor(), _center, _point2);
                 //brush = new System.Drawing.Drawing2D.LinearGradientBrush(
-                //  point1.ToPointF(), point2.ToPointF(),
+                //  center.ToPointF(), point2.ToPointF(),
                 //  color1.ToGdiColor(), color2.ToGdiColor());
 #else
                 GradientStop gs1 = new GradientStop();
@@ -246,7 +226,7 @@ namespace PdfSharpCore.Drawing
                 gsc.Add(gs2);
 
                 brush = new LinearGradientBrush(gsc, 0);
-                brush.StartPoint = _point1;
+                brush.StartPoint = _center;
                 brush.EndPoint = _point2;
 #endif
             }
@@ -275,10 +255,7 @@ namespace PdfSharpCore.Drawing
         }
 #endif
 
-
-        internal bool _useRect;
-        internal XPoint _point1, _point2;
-        internal XRect _rect;
-        internal XLinearGradientMode _linearGradientMode;
+        internal XPoint _center1, _center2;
+        internal double _r1, _r2;
     }
 }

--- a/PdfSharpCore/Pdf.Advanced/PdfShading.cs
+++ b/PdfSharpCore/Pdf.Advanced/PdfShading.cs
@@ -102,8 +102,8 @@ namespace PdfSharpCore.Pdf.Advanced
             Elements[Keys.Function] = function;
             //Elements[Keys.Extend] = new PdfRawItem("[true true]");
 
-            string clr1 = "[" + PdfEncoders.ToString(color1, colorMode) + "]";
-            string clr2 = "[" + PdfEncoders.ToString(color2, colorMode) + "]";
+            string clr1 = "[" + PdfEncoders.ToString(color1, colorMode, true) + "]";
+            string clr2 = "[" + PdfEncoders.ToString(color2, colorMode, true) + "]";
 
             function.Elements["/FunctionType"] = new PdfInteger(2);
             function.Elements["/C0"] = new PdfLiteral(clr1);
@@ -188,8 +188,8 @@ namespace PdfSharpCore.Pdf.Advanced
             Elements[Keys.Function] = function;
             //Elements[Keys.Extend] = new PdfRawItem("[true true]");
 
-            string clr1 = "[" + PdfEncoders.ToString(color1, colorMode) + "]";
-            string clr2 = "[" + PdfEncoders.ToString(color2, colorMode) + "]";
+            string clr1 = "[" + PdfEncoders.ToString(color1, colorMode, true) + "]";
+            string clr2 = "[" + PdfEncoders.ToString(color2, colorMode, true) + "]";
 
             function.Elements["/FunctionType"] = new PdfInteger(2);
             function.Elements["/C0"] = new PdfLiteral(clr1);

--- a/PdfSharpCore/Pdf.Advanced/PdfShading.cs
+++ b/PdfSharpCore/Pdf.Advanced/PdfShading.cs
@@ -236,8 +236,8 @@ namespace PdfSharpCore.Pdf.Advanced
 
             /// <summary>
             /// (Optional) An array of four numbers giving the left, bottom, right, and top coordinates, 
-            /// respectively, of the shading?s bounding box. The coordinates are interpreted in the 
-            /// shading?s target coordinate space. If present, this bounding box is applied as a temporary 
+            /// respectively, of the shading's bounding box. The coordinates are interpreted in the 
+            /// shading's target coordinate space. If present, this bounding box is applied as a temporary 
             /// clipping boundary when the shading is painted, in addition to the current clipping path
             /// and any other clipping boundaries in effect at that time.
             /// </summary>
@@ -247,7 +247,7 @@ namespace PdfSharpCore.Pdf.Advanced
             /// <summary>
             /// (Optional) A flag indicating whether to filter the shading function to prevent aliasing 
             /// artifacts. The shading operators sample shading functions at a rate determined by the 
-            /// resolution of the output device. Aliasing can occur if the function is not smooth?that
+            /// resolution of the output device. Aliasing can occur if the function is not smooth - that
             /// is, if it has a high spatial frequency relative to the sampling rate. Anti-aliasing can
             /// be computationally expensive and is usually unnecessary, since most shading functions
             /// are smooth enough or are sampled at a high enough frequency to avoid aliasing effects.
@@ -262,7 +262,7 @@ namespace PdfSharpCore.Pdf.Advanced
 
             /// <summary>
             /// (Required) An array of four numbers [x0 y0 x1 y1] specifying the starting and
-            /// ending coordinates of the axis, expressed in the shading?s target coordinate space.
+            /// ending coordinates of the axis, expressed in the shading's target coordinate space.
             /// </summary>
             [KeyInfo(KeyType.Array | KeyType.Required)]
             public const string Coords = "/Coords";
@@ -279,9 +279,9 @@ namespace PdfSharpCore.Pdf.Advanced
 
             /// <summary>
             /// (Required) A 1-in, n-out function or an array of n 1-in, 1-out functions (where n
-            /// is the number of color components in the shading dictionary?s color space). The
+            /// is the number of color components in the shading dictionary's color space). The
             /// function(s) are called with values of the parametric variable t in the domain defined
-            /// by the Domain entry. Each function?s domain must be a superset of that of the shading
+            /// by the Domain entry. Each function's domain must be a superset of that of the shading
             /// dictionary. If the value returned by the function for a given color component is out
             /// of range, it is adjusted to the nearest valid value.
             /// </summary>

--- a/PdfSharpCore/Pdf.Advanced/PdfShading.cs
+++ b/PdfSharpCore/Pdf.Advanced/PdfShading.cs
@@ -53,6 +53,65 @@ namespace PdfSharpCore.Pdf.Advanced
             : base(document)
         { }
 
+        internal void SetupFromBrush(XBaseGradientBrush brush, XGraphicsPdfRenderer renderer)
+        {
+            if (brush is XRadialGradientBrush radialBrush)
+                SetupFromBrush(radialBrush, renderer);
+            else if (brush is XLinearGradientBrush linearBrush)
+                SetupFromBrush(linearBrush, renderer);
+            else
+                throw new ArgumentException("Unsupoorted XGradientBrush: " + brush);
+        }
+
+        internal void SetupFromBrush(XRadialGradientBrush brush, XGraphicsPdfRenderer renderer)
+        {
+            if (brush == null)
+                throw new ArgumentNullException("brush");
+
+            PdfColorMode colorMode = _document.Options.ColorMode;
+            XColor color1 = ColorSpaceHelper.EnsureColorMode(colorMode, brush._color1);
+            XColor color2 = ColorSpaceHelper.EnsureColorMode(colorMode, brush._color2);
+
+            PdfDictionary function = new PdfDictionary();
+
+            Elements[Keys.ShadingType] = new PdfInteger(3);
+            if (colorMode != PdfColorMode.Cmyk)
+                Elements[Keys.ColorSpace] = new PdfName("/DeviceRGB");
+            else
+                Elements[Keys.ColorSpace] = new PdfName("/DeviceCMYK");
+
+            XPoint p1 = renderer.WorldToView(brush._center1);
+            XPoint p2 = renderer.WorldToView(brush._center2);
+
+            var rv1 = renderer.WorldToView(new XPoint(brush._r1 + brush._center1.X, brush._center1.Y));
+            var rv2 = renderer.WorldToView(new XPoint(brush._r2 + brush._center2.X, brush._center2.Y));
+
+            var dx1 = rv1.X - p1.X;
+            var dy1 = rv1.Y - p1.Y;
+            var dx2 = rv2.X - p2.X;
+            var dy2 = rv2.Y - p2.Y;
+
+            var r1 = Math.Sqrt(dx1 * dx1 + dy1 * dy1);
+            var r2 = Math.Sqrt(dx2 * dx2 + dy2 * dy2);
+
+            const string format = Config.SignificantFigures3;
+            Elements[Keys.Coords] = new PdfLiteral("[{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "}]", p1.X, p1.Y, r1, p2.X, p2.Y, r2);
+
+            //Elements[Keys.Background] = new PdfRawItem("[0 1 1]");
+            //Elements[Keys.Domain] = 
+            Elements[Keys.Function] = function;
+            //Elements[Keys.Extend] = new PdfRawItem("[true true]");
+
+            string clr1 = "[" + PdfEncoders.ToString(color1, colorMode) + "]";
+            string clr2 = "[" + PdfEncoders.ToString(color2, colorMode) + "]";
+
+            function.Elements["/FunctionType"] = new PdfInteger(2);
+            function.Elements["/C0"] = new PdfLiteral(clr1);
+            function.Elements["/C1"] = new PdfLiteral(clr2);
+            function.Elements["/Domain"] = new PdfLiteral("[0 1]");
+            function.Elements["/N"] = new PdfInteger(1);
+        }
+
         /// <summary>
         /// Setups the shading from the specified brush.
         /// </summary>
@@ -177,8 +236,8 @@ namespace PdfSharpCore.Pdf.Advanced
 
             /// <summary>
             /// (Optional) An array of four numbers giving the left, bottom, right, and top coordinates, 
-            /// respectively, of the shading’s bounding box. The coordinates are interpreted in the 
-            /// shading’s target coordinate space. If present, this bounding box is applied as a temporary 
+            /// respectively, of the shading?s bounding box. The coordinates are interpreted in the 
+            /// shading?s target coordinate space. If present, this bounding box is applied as a temporary 
             /// clipping boundary when the shading is painted, in addition to the current clipping path
             /// and any other clipping boundaries in effect at that time.
             /// </summary>
@@ -188,7 +247,7 @@ namespace PdfSharpCore.Pdf.Advanced
             /// <summary>
             /// (Optional) A flag indicating whether to filter the shading function to prevent aliasing 
             /// artifacts. The shading operators sample shading functions at a rate determined by the 
-            /// resolution of the output device. Aliasing can occur if the function is not smooth—that
+            /// resolution of the output device. Aliasing can occur if the function is not smooth?that
             /// is, if it has a high spatial frequency relative to the sampling rate. Anti-aliasing can
             /// be computationally expensive and is usually unnecessary, since most shading functions
             /// are smooth enough or are sampled at a high enough frequency to avoid aliasing effects.
@@ -203,7 +262,7 @@ namespace PdfSharpCore.Pdf.Advanced
 
             /// <summary>
             /// (Required) An array of four numbers [x0 y0 x1 y1] specifying the starting and
-            /// ending coordinates of the axis, expressed in the shading’s target coordinate space.
+            /// ending coordinates of the axis, expressed in the shading?s target coordinate space.
             /// </summary>
             [KeyInfo(KeyType.Array | KeyType.Required)]
             public const string Coords = "/Coords";
@@ -220,9 +279,9 @@ namespace PdfSharpCore.Pdf.Advanced
 
             /// <summary>
             /// (Required) A 1-in, n-out function or an array of n 1-in, 1-out functions (where n
-            /// is the number of color components in the shading dictionary’s color space). The
+            /// is the number of color components in the shading dictionary?s color space). The
             /// function(s) are called with values of the parametric variable t in the domain defined
-            /// by the Domain entry. Each function’s domain must be a superset of that of the shading
+            /// by the Domain entry. Each function?s domain must be a superset of that of the shading
             /// dictionary. If the value returned by the function for a given color component is out
             /// of range, it is adjusted to the nearest valid value.
             /// </summary>

--- a/PdfSharpCore/Pdf.Advanced/PdfShadingPattern.cs
+++ b/PdfSharpCore/Pdf.Advanced/PdfShadingPattern.cs
@@ -58,6 +58,21 @@ namespace PdfSharpCore.Pdf.Advanced
         /// <summary>
         /// Setups the shading pattern from the specified brush.
         /// </summary>
+        internal void SetupFromBrush(XBaseGradientBrush brush, XMatrix matrix, XGraphicsPdfRenderer renderer)
+        {
+            if (brush == null)
+                throw new ArgumentNullException("brush");
+
+            PdfShading shading = new PdfShading(_document);
+            shading.SetupFromBrush(brush, renderer);
+            Elements[Keys.Shading] = shading;
+            //Elements[Keys.Matrix] = new PdfLiteral("[" + PdfEncoders.ToString(matrix) + "]");
+            Elements.SetMatrix(Keys.Matrix, matrix);
+        }
+
+        /// <summary>
+        /// Setups the shading pattern from the specified brush.
+        /// </summary>
         internal void SetupFromBrush(XLinearGradientBrush brush, XMatrix matrix, XGraphicsPdfRenderer renderer)
         {
             if (brush == null)
@@ -90,7 +105,7 @@ namespace PdfSharpCore.Pdf.Advanced
             public const string PatternType = "/PatternType";
 
             /// <summary>
-            /// (Required) A shading object (see below) defining the shading pattern’s gradient fill.
+            /// (Required) A shading object (see below) defining the shading pattern?s gradient fill.
             /// </summary>
             [KeyInfo(KeyType.Dictionary | KeyType.Required)]
             public const string Shading = "/Shading";

--- a/PdfSharpCore/Pdf.Advanced/PdfShadingPattern.cs
+++ b/PdfSharpCore/Pdf.Advanced/PdfShadingPattern.cs
@@ -105,7 +105,7 @@ namespace PdfSharpCore.Pdf.Advanced
             public const string PatternType = "/PatternType";
 
             /// <summary>
-            /// (Required) A shading object (see below) defining the shading pattern?s gradient fill.
+            /// (Required) A shading object (see below) defining the shading pattern's gradient fill.
             /// </summary>
             [KeyInfo(KeyType.Dictionary | KeyType.Required)]
             public const string Shading = "/Shading";

--- a/PdfSharpCore/Pdf.Internal/PdfEncoders.cs
+++ b/PdfSharpCore/Pdf.Internal/PdfEncoders.cs
@@ -426,7 +426,7 @@ namespace PdfSharpCore.Pdf.Internal
         }
 
         /// <summary>
-        /// Converts WinAnsi to DocEncode characters. Incomplete, just maps € and some other characters.
+        /// Converts WinAnsi to DocEncode characters. Incomplete, just maps ? and some other characters.
         /// </summary>
         static byte[] docencode_______ = new byte[256]
         {
@@ -605,8 +605,8 @@ namespace PdfSharpCore.Pdf.Internal
                       color.C, color.M, color.Y, color.K);
 
                 default:
-                    return String.Format(CultureInfo.InvariantCulture, "{0:" + format + "} {1:" + format + "} {2:" + format + "}",
-                      color.R / 255.0, color.G / 255.0, color.B / 255.0);
+                    return String.Format(CultureInfo.InvariantCulture, "{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "}",
+                      color.R / 255.0, color.G / 255.0, color.B / 255.0, color.A);
             }
         }
 

--- a/PdfSharpCore/Pdf.Internal/PdfEncoders.cs
+++ b/PdfSharpCore/Pdf.Internal/PdfEncoders.cs
@@ -590,7 +590,7 @@ namespace PdfSharpCore.Pdf.Internal
         /// <summary>
         /// Converts an XColor into a string with up to 3 decimal digits and a decimal point.
         /// </summary>
-        public static string ToString(XColor color, PdfColorMode colorMode)
+        public static string ToString(XColor color, PdfColorMode colorMode, bool withAlpha = false)
         {
             const string format = Config.SignificantFigures3;
 
@@ -605,8 +605,13 @@ namespace PdfSharpCore.Pdf.Internal
                       color.C, color.M, color.Y, color.K);
 
                 default:
-                    return String.Format(CultureInfo.InvariantCulture, "{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "}",
-                      color.R / 255.0, color.G / 255.0, color.B / 255.0, color.A);
+                    {
+                        if (withAlpha)
+                            return String.Format(CultureInfo.InvariantCulture, "{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "}", color.R / 255.0, color.G / 255.0, color.B / 255.0, color.A);
+                        else
+                            return String.Format(CultureInfo.InvariantCulture, "{0:" + format + "} {1:" + format + "} {2:" + format + "}", color.R / 255.0, color.G / 255.0, color.B / 255.0);
+
+                    }
             }
         }
 

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -35,8 +35,8 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta0009" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
+    <ProjectReference Include="..\SixLabors\Fonts\src\SixLabors.Fonts\SixLabors.Fonts.csproj" />
+    <ProjectReference Include="..\SixLabors\ImageSharp\src\ImageSharp\ImageSharp.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request adds the following new functionality:

- Radial Gradients;
- Support of Alpha channel in gradient stops;
- Support of using an XBrush as the "color" source for an XPen (an alternative to using an XColor);
- XGraphicsPath.MoveTo(XPoint) method because it is nearly impossible to convert from SVG or AndroidVector without it (please show me I'm wrong ... it would be greatly appreciated).

Notes:
- I have added the SixLabors.Fonts, SixLabors.Core, and SixLabors.ImageSharp repos as git SubModules because I could not get the project to build and run in VisualStudio Mac without doing so.