### PR TITLE
Stripped semi-colon and comma from release note body

### DIFF
--- a/.ci/tasks/publish-nugget.yaml
+++ b/.ci/tasks/publish-nugget.yaml
@@ -23,5 +23,5 @@ run:
     VERSION=$(cat version/version)
     cd "source/${PROJECT}"
     dotnet build /p:GeneratePackageOnBuild=False /p:AssemblyVersion=${VERSION} /p:FileVersion=${VERSION} -c Release "${PROJECT}.csproj"
-    dotnet pack /p:PackageVersion=${VERSION} /p:PackageTags="${NUGGET_TAGS} $(cat ../.git/ref)" /p:PackageReleaseNotes="$(cat ../.git/commit_message)" --no-restore -c Release -o out "${PROJECT}.csproj"
+    dotnet pack /p:PackageVersion=${VERSION} /p:PackageTags="${NUGGET_TAGS} $(cat ../.git/ref)" /p:PackageReleaseNotes="$(sed -e 's/;/ /g' -e 's/,/ /g' ../.git/commit_message)" --no-restore -c Release -o out "${PROJECT}.csproj"
     dotnet nuget push out/${PROJECT}.${VERSION}.nupkg -k ${NUGGET_API_KEY} -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Convert `;` and `,` to space as they are treated as separators/delimeters by MSBuild.
Please see [here](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2015&redirectedfrom=MSDN) for details