### PR TITLE
#77 Adds option to enable annotation copying

### DIFF
--- a/PdfSharpCore/Pdf/PdfDocument.cs
+++ b/PdfSharpCore/Pdf/PdfDocument.cs
@@ -826,11 +826,11 @@ namespace PdfSharpCore.Pdf
         /// it is imported to this document. In this case the returned page is not the same
         /// object as the specified one.
         /// </summary>
-        public PdfPage AddPage(PdfPage page)
+        public PdfPage AddPage(PdfPage page, AnnotationCopyingType annotationCopying = AnnotationCopyingType.DoNotCopy)
         {
             if (!CanModify)
                 throw new InvalidOperationException(PSSR.CannotModify);
-            return Catalog.Pages.Add(page);
+            return Catalog.Pages.Add(page, annotationCopying);
         }
 
         /// <summary>
@@ -848,11 +848,11 @@ namespace PdfSharpCore.Pdf
         /// it is imported to this document. In this case the returned page is not the same
         /// object as the specified one.
         /// </summary>
-        public PdfPage InsertPage(int index, PdfPage page)
+        public PdfPage InsertPage(int index, PdfPage page, AnnotationCopyingType annotationCopying = AnnotationCopyingType.DoNotCopy)
         {
             if (!CanModify)
                 throw new InvalidOperationException(PSSR.CannotModify);
-            return Catalog.Pages.Insert(index, page);
+            return Catalog.Pages.Insert(index, page, annotationCopying);
         }
 
         /// <summary>

--- a/PdfSharpCore/Pdf/PdfPages.cs
+++ b/PdfSharpCore/Pdf/PdfPages.cs
@@ -115,9 +115,9 @@ namespace PdfSharpCore.Pdf
         /// Adds the specified PdfPage to the end of this document and maybe returns a new PdfPage object.
         /// The value returned is a new object if the added page comes from a foreign document.
         /// </summary>
-        public PdfPage Add(PdfPage page)
+        public PdfPage Add(PdfPage page, AnnotationCopyingType annotationCopying = AnnotationCopyingType.DoNotCopy)
         {
-            return Insert(Count, page);
+            return Insert(Count, page, annotationCopying);
         }
 
         /// <summary>
@@ -134,7 +134,7 @@ namespace PdfSharpCore.Pdf
         /// Inserts the specified PdfPage at the specified position to this document and maybe returns a new PdfPage object.
         /// The value returned is a new object if the inserted page comes from a foreign document.
         /// </summary>
-        public PdfPage Insert(int index, PdfPage page)
+        public PdfPage Insert(int index, PdfPage page, AnnotationCopyingType annotationCopying = AnnotationCopyingType.DoNotCopy)
         {
             if (page == null)
                 throw new ArgumentNullException("page");
@@ -181,7 +181,7 @@ namespace PdfSharpCore.Pdf
             {
                 // Case: Page is from an external document -> import it.
                 PdfPage importPage = page;
-                page = ImportExternalPage(importPage);
+                page = ImportExternalPage(importPage, annotationCopying);
                 Owner._irefTable.Add(page);
 
                 // Add page substitute to importedObjectTable.
@@ -204,7 +204,8 @@ namespace PdfSharpCore.Pdf
         /// <param name="document">The document to be inserted.</param>
         /// <param name="startIndex">The index of the first page to be inserted.</param>
         /// <param name="pageCount">The number of pages to be inserted.</param>
-        public void InsertRange(int index, PdfDocument document, int startIndex, int pageCount)
+        /// <param name="annotationCopying">Annotation copying action, by default annotations are not copied.</param>
+        public void InsertRange(int index, PdfDocument document, int startIndex, int pageCount, AnnotationCopyingType annotationCopying = AnnotationCopyingType.DoNotCopy)
         {
             if (document == null)
                 throw new ArgumentNullException("document");
@@ -229,7 +230,7 @@ namespace PdfSharpCore.Pdf
                 idx++, insertIndex++, importIndex++)
             {
                 PdfPage importPage = document.Pages[importIndex];
-                PdfPage page = ImportExternalPage(importPage);
+                PdfPage page = ImportExternalPage(importPage, annotationCopying);
                 insertPages[idx] = page;
                 importPages[idx] = importPage;
 
@@ -357,12 +358,13 @@ namespace PdfSharpCore.Pdf
         /// </summary>
         /// <param name="index">The index in this document where to insert the page .</param>
         /// <param name="document">The document to be inserted.</param>
-        public void InsertRange(int index, PdfDocument document)
+        /// <param name="annotationCopying">Annotation copying action, by default annotations are not copied.</param>
+        public void InsertRange(int index, PdfDocument document, AnnotationCopyingType annotationCopying = AnnotationCopyingType.DoNotCopy)
         {
             if (document == null)
                 throw new ArgumentNullException("document");
 
-            InsertRange(index, document, 0, document.PageCount);
+            InsertRange(index, document, 0, document.PageCount, annotationCopying);
         }
 
         /// <summary>
@@ -371,12 +373,13 @@ namespace PdfSharpCore.Pdf
         /// <param name="index">The index in this document where to insert the page .</param>
         /// <param name="document">The document to be inserted.</param>
         /// <param name="startIndex">The index of the first page to be inserted.</param>
-        public void InsertRange(int index, PdfDocument document, int startIndex)
+        /// <param name="annotationCopying">Annotation copying action, by default annotations are not copied.</param>
+        public void InsertRange(int index, PdfDocument document, int startIndex, AnnotationCopyingType annotationCopying = AnnotationCopyingType.DoNotCopy)
         {
             if (document == null)
                 throw new ArgumentNullException("document");
 
-            InsertRange(index, document, startIndex, document.PageCount - startIndex);
+            InsertRange(index, document, startIndex, document.PageCount - startIndex, annotationCopying);
         }
 
         /// <summary>
@@ -423,7 +426,7 @@ namespace PdfSharpCore.Pdf
         /// of their transitive closure. Any reuse of already imported objects is not intended because
         /// any modification of an imported page must not change another page.
         /// </summary>
-        PdfPage ImportExternalPage(PdfPage importPage)
+        PdfPage ImportExternalPage(PdfPage importPage, AnnotationCopyingType annotationCopying = AnnotationCopyingType.DoNotCopy)
         {
             if (importPage.Owner._openMode != PdfDocumentOpenMode.Import)
                 throw new InvalidOperationException("A PDF document must be opened with PdfDocumentOpenMode.Import to import pages from it.");
@@ -439,13 +442,12 @@ namespace PdfSharpCore.Pdf
             CloneElement(page, importPage, PdfPage.Keys.BleedBox, true);
             CloneElement(page, importPage, PdfPage.Keys.TrimBox, true);
             CloneElement(page, importPage, PdfPage.Keys.ArtBox, true);
-#if true
-            // Do not deep copy annotations.
-            //CloneElement(page, importPage, PdfPage.Keys.Annots, false);
-#else
-            // Deep copy annotations.
-            CloneElement(page, importPage, PdfPage.Keys.Annots, true);
-#endif
+
+            if (annotationCopying == AnnotationCopyingType.ShallowCopy)
+                CloneElement(page, importPage, PdfPage.Keys.Annots, false);
+            else if (annotationCopying == AnnotationCopyingType.DeepCopy)
+                CloneElement(page, importPage, PdfPage.Keys.Annots, true);
+
             // ReSharper restore AccessToStaticMemberViaDerivedType
             // TODO more elements?
             return page;

--- a/PdfSharpCore/Pdf/enums/AnnotationCopyingType.cs
+++ b/PdfSharpCore/Pdf/enums/AnnotationCopyingType.cs
@@ -1,0 +1,21 @@
+﻿namespace PdfSharpCore.Pdf
+{
+    /// <summary>
+    /// Defines how annotations should be copied.
+    /// </summary>
+    public enum AnnotationCopyingType
+    {
+        /// <summary>
+        /// Skips annotation copying.
+        /// </summary>
+        DoNotCopy,
+        /// <summary>
+        /// Does a shallow copy.
+        /// </summary>
+        ShallowCopy,
+        /// <summary>
+        /// Performs deep copy.
+        /// </summary>
+        DeepCopy
+    }
+}


### PR DESCRIPTION
Related to #77, adding option to perform annotation copying.

Added simple optional parameter full options object seemed a bit like an overkill.