### PR TITLE
Added SixLabors.Core nugget dependecy

### DIFF
--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -53,4 +53,7 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
   <ItemGroup>
     <Folder Include="Resources\images\" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0008" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
`SixLabors.Fonts` and `SixLabors.ImageSharp` have their DLLs added to the nugget but they need SixLabors.Core.

This PR adds a dependency on `SixLabors.Core` nugget