### PR TITLE
Use imagesharp nugget instead of project reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,0 @@
-[submodule "SixLabors/Fonts"]
-	path = SixLabors/Fonts
-	url = https://github.com/SixLabors/Fonts.git
-[submodule "SixLabors/Core"]
-	path = SixLabors/Core
-	url = https://github.com/SixLabors/Core.git
-[submodule "SixLabors/ImageSharp"]
-	path = SixLabors/ImageSharp
-	url = https://github.com/SixLabors/ImageSharp.git

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -6,7 +6,7 @@
     <Authors>Stefan Steiger and Contributors</Authors>
     <Description>PdfSharp for .NET Core
 
-PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally MigraDoc has been ported as well (from version 1.32). Images have been implemented with ImageSharp from https://github.com/SixLabors/ImageSharp</Description>
+PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally MigraDoc has been ported as well (from version 1.32). Images have been implemented with ImageSharp from https://www.nuget.org/packages/SixLabors.ImageSharp</Description>
     <Copyright>Copyright (c) 2005-2007 empira Software GmbH, Cologne (Germany)</Copyright>
     <PackageLicenseUrl>https://github.com/ststeiger/PdfSharpCore</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/ststeiger/PdfSharpCore</PackageProjectUrl>

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -14,14 +14,7 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
     <PackageReleaseNotes>PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally MigraDoc has been ported as well (from version 1.32)</PackageReleaseNotes>
     <PackageTags>NuggetV1.0.0 (8ea343d5898342a563b9d4df2d67e27aaea9ac01)</PackageTags>
     <summary>PdfSharp for .NET Core</summary>
-    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
-
-  <Target DependsOnTargets="ResolveReferences" Name="CopyProjectReferencesToPackage">
-    <ItemGroup>
-      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
-    </ItemGroup>
-  </Target>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;NETCOREAPP1_1;NETCOREAPP1_1;PORTABLE</DefineConstants>
@@ -42,18 +35,10 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SixLabors\Fonts\src\SixLabors.Fonts\SixLabors.Fonts.csproj">
-      <PrivateAssets>all</PrivateAssets>
-    </ProjectReference>
-    <ProjectReference Include="..\SixLabors\ImageSharp\src\ImageSharp\ImageSharp.csproj">
-      <PrivateAssets>all</PrivateAssets>
-    </ProjectReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="Resources\images\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0008" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-rc0003" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta0013" />
   </ItemGroup>
 </Project>

--- a/PdfSharpCore/Utils/FontResolver.cs
+++ b/PdfSharpCore/Utils/FontResolver.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using PdfSharpCore.Drawing;
@@ -65,7 +66,7 @@ namespace PdfSharpCore.Utils
                 try
                 {
                     FontDescription fontDescription = FontDescription.LoadDescription(fontPathFile);
-                    string fontFamilyName = fontDescription.FontFamily;
+                    string fontFamilyName = fontDescription.FontFamily(CultureInfo.InvariantCulture);
                     Console.WriteLine(fontPathFile);
 
                     if (tmpFontFamiliesTtfFilesDict.TryGetValue(fontFamilyName, out List<string> familyTtfFiles))

--- a/PdfSharpCore/Utils/ImageSharpImageSource.cs
+++ b/PdfSharpCore/Utils/ImageSharpImageSource.cs
@@ -10,7 +10,7 @@ using SixLabors.ImageSharp.Formats.Png;
 
 namespace PdfSharpCore.Utils
 {
-    public class ImageSharpImageSource<TPixel> : ImageSource where TPixel : struct, IPixel<TPixel>
+    public class ImageSharpImageSource<TPixel> : ImageSource where TPixel : unmanaged, IPixel<TPixel>
     {
         protected override IImageSource FromBinaryImpl(string name, Func<byte[]> imageSource, int? quality = 75)
         {
@@ -33,7 +33,7 @@ namespace PdfSharpCore.Utils
             }
         }
 
-        private class ImageSharpImageSourceImpl<TPixel2> : IImageSource where TPixel2 : struct, IPixel<TPixel2>
+        private class ImageSharpImageSourceImpl<TPixel2> : IImageSource where TPixel2 : unmanaged, IPixel<TPixel2>
         {
             private Image<TPixel2> Image { get; }
             private readonly int _quality;


### PR DESCRIPTION
Revert back to using only nugget packages for dependecies

Fixes #98 