### PR TITLE
Retarget aghacks with dotnet standard 1.3 as a minimum

### DIFF
--- a/PdfSharpCore/Pdf/PdfInteger.cs
+++ b/PdfSharpCore/Pdf/PdfInteger.cs
@@ -38,7 +38,7 @@ namespace PdfSharpCore.Pdf
     /// Represents a direct integer value.
     /// </summary>
     [DebuggerDisplay("({Value})")]
-    public sealed class PdfInteger : PdfNumber, IConvertible, System.IConvertible
+    public sealed class PdfInteger : PdfNumber, IConvertible
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PdfInteger"/> class.
@@ -80,95 +80,6 @@ namespace PdfSharpCore.Pdf
         {
             writer.Write(this);
         }
-
-        #region System.IConvertible Members
-
-        uint System.IConvertible.ToUInt32(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToUInt32(provider);
-        }
-
-        ulong System.IConvertible.ToUInt64(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToUInt64(provider);
-        }
-
-        long System.IConvertible.ToInt64(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToInt64(provider);
-        }
-
-        sbyte System.IConvertible.ToSByte(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToSByte(provider);
-        }
-
-        float System.IConvertible.ToSingle(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToSingle(provider);
-        }
-
-        string System.IConvertible.ToString(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToString(provider);
-        }
-
-        object System.IConvertible.ToType(Type conversionType, IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToType(conversionType, provider);
-        }
-
-        ushort System.IConvertible.ToUInt16(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToUInt16(provider);
-        }
-
-        decimal System.IConvertible.ToDecimal(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToDecimal(provider);
-        }
-
-        double System.IConvertible.ToDouble(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToDouble(provider);
-        }
-
-        short System.IConvertible.ToInt16(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToInt16(provider);
-        }
-
-        int System.IConvertible.ToInt32(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToInt32(provider);
-        }
-
-        char System.IConvertible.ToChar(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToChar(provider);
-        }
-
-        DateTime System.IConvertible.ToDateTime(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToDateTime(provider);
-        }
-
-        System.TypeCode System.IConvertible.GetTypeCode()
-        {
-            return (System.TypeCode)((IConvertible)this).GetTypeCode();
-        }
-
-        bool System.IConvertible.ToBoolean(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToBoolean(provider);
-        }
-
-        byte System.IConvertible.ToByte(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToByte(provider);
-        }
-
-        #endregion
 
         #region IConvertible Members
 

--- a/PdfSharpCore/Pdf/PdfUInteger.cs
+++ b/PdfSharpCore/Pdf/PdfUInteger.cs
@@ -38,7 +38,7 @@ namespace PdfSharpCore.Pdf
     /// Represents a direct unsigned integer value.
     /// </summary>
     [DebuggerDisplay("({Value})")]
-    public sealed class PdfUInteger : PdfNumber, IConvertible, System.IConvertible
+    public sealed class PdfUInteger : PdfNumber, IConvertible
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PdfUInteger"/> class.
@@ -82,95 +82,6 @@ namespace PdfSharpCore.Pdf
         {
             writer.Write(this);
         }
-
-        #region System.IConvertible Members
-
-        uint System.IConvertible.ToUInt32(IFormatProvider provider)
-        {
-            return ToUInt32(provider);
-        }
-
-        ulong System.IConvertible.ToUInt64(IFormatProvider provider)
-        {
-            return ToUInt64(provider);
-        }
-
-        long System.IConvertible.ToInt64(IFormatProvider provider)
-        {
-            return ToInt64(provider);
-        }
-
-        sbyte System.IConvertible.ToSByte(IFormatProvider provider)
-        {
-            return ToSByte(provider);
-        }
-
-        float System.IConvertible.ToSingle(IFormatProvider provider)
-        {
-            return ToSingle(provider);
-        }
-
-        string System.IConvertible.ToString(IFormatProvider provider)
-        {
-            return ((IConvertible)this).ToString(provider);
-        }
-
-        object System.IConvertible.ToType(Type conversionType, IFormatProvider provider)
-        {
-            return ToType(conversionType, provider);
-        }
-
-        ushort System.IConvertible.ToUInt16(IFormatProvider provider)
-        {
-            return ToUInt16(provider);
-        }
-
-        decimal System.IConvertible.ToDecimal(IFormatProvider provider)
-        {
-            return ToDecimal(provider);
-        }
-
-        double System.IConvertible.ToDouble(IFormatProvider provider)
-        {
-            return ToDouble(provider);
-        }
-
-        short System.IConvertible.ToInt16(IFormatProvider provider)
-        {
-            return ToInt16(provider);
-        }
-
-        int System.IConvertible.ToInt32(IFormatProvider provider)
-        {
-            return ToInt32(provider);
-        }
-
-        char System.IConvertible.ToChar(IFormatProvider provider)
-        {
-            return ToChar(provider);
-        }
-
-        DateTime System.IConvertible.ToDateTime(IFormatProvider provider)
-        {
-            return ToDateTime(provider);
-        }
-
-        System.TypeCode System.IConvertible.GetTypeCode()
-        {
-            return (System.TypeCode)GetTypeCode();
-        }
-
-        bool System.IConvertible.ToBoolean(IFormatProvider provider)
-        {
-            return ToBoolean(provider);
-        }
-
-        byte System.IConvertible.ToByte(IFormatProvider provider)
-        {
-            return ToByte(provider);
-        }
-
-        #endregion
 
         #region IConvertible Members
 

--- a/PdfSharpCore/SilverlightInternals/AgHacks.cs
+++ b/PdfSharpCore/SilverlightInternals/AgHacks.cs
@@ -27,21 +27,10 @@
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if SILVERLIGHT || UWP || PORTABLE
+#if NETSTANDARD1_3
 using System;
 
-#if SILVERLIGHT
-using System.Net;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Documents;
-using System.Windows.Ink;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Animation;
-using System.Windows.Shapes;
-#endif
-
+// Available starting in standard 2.0
 public class BrowsableAttribute : Attribute
 {
     public BrowsableAttribute(bool browsable)
@@ -51,12 +40,14 @@ public class BrowsableAttribute : Attribute
 
 /// <summary>
 /// SerializableAttribute for compatibility with Silverlight.
+/// Available starting in standard 2.0
 /// </summary>
 public class SerializableAttribute : Attribute
 { }
 
 /// <summary>
 /// ICloneable for compatibility with Silverlight.
+/// Available starting in standard 2.0
 /// </summary>
 public interface ICloneable
 {
@@ -70,6 +61,7 @@ namespace PdfSharpCore
 {
     /// <summary>
     /// The exception that is thrown when a non-fatal application error occurs.
+    /// Available starting in standard 2.0
     /// </summary>
     public class ApplicationException : Exception
     {
@@ -95,98 +87,10 @@ namespace PdfSharpCore
             : base(message, innerException)
         { }
     }
-#if PORTABLE
-    public enum TypeCode
-    {
-
-        Empty = 0,
-        Object = 1,
-        DBNull = 2,
-        Boolean = 3,
-        Char = 4,
-        SByte = 5,
-        Byte = 6,
-        Int16 = 7,
-        UInt16 = 8,
-        Int32 = 9,
-        UInt32 = 10,
-        Int64 = 11,
-        UInt64 = 12,
-        Single = 13,
-        Double = 14,
-        Decimal = 15,
-        DateTime = 16,
-        String = 18
-    }
-
-    public interface IConvertible
-    {
-        TypeCode GetTypeCode();
-
-        bool ToBoolean(IFormatProvider provider);
-        byte ToByte(IFormatProvider provider);
-        char ToChar(IFormatProvider provider);
-        DateTime ToDateTime(IFormatProvider provider);
-        decimal ToDecimal(IFormatProvider provider);
-        double ToDouble(IFormatProvider provider);
-        short ToInt16(IFormatProvider provider);
-        int ToInt32(IFormatProvider provider);
-        long ToInt64(IFormatProvider provider);
-        sbyte ToSByte(IFormatProvider provider);
-        float ToSingle(IFormatProvider provider);
-        string ToString(IFormatProvider provider);
-        object ToType(Type conversionType, IFormatProvider provider);
-        ushort ToUInt16(IFormatProvider provider);
-        uint ToUInt32(IFormatProvider provider);
-        ulong ToUInt64(IFormatProvider provider);
-    }
-#endif
-
-#if SILVERLIGHT || PORTABLE
-    /// <summary>
-    /// The exception that is thrown when the value of an argument is outside
-    /// the allowable range of values as defined by the invoked method.
-    /// </summary>
-    public class ArgumentOutOfRangeException : ArgumentException
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArgumentOutOfRangeException"/> class.
-        /// </summary>
-        public ArgumentOutOfRangeException()
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArgumentOutOfRangeException"/> class.
-        /// </summary>
-        public ArgumentOutOfRangeException(string message)
-            : base(message)
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArgumentOutOfRangeException"/> class.
-        /// </summary>
-        public ArgumentOutOfRangeException(string message, string message2)
-            : base(message, message2)
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArgumentOutOfRangeException"/> class.
-        /// </summary>
-        public ArgumentOutOfRangeException(string message, object value, string message2)
-            : base(message, message2)
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArgumentOutOfRangeException"/> class.
-        /// </summary>
-        public ArgumentOutOfRangeException(string message, Exception innerException)
-            : base(message, innerException)
-        { }
-    }
-#endif
 
     /// <summary>
     /// The exception thrown when using invalid arguments that are enumerators.
+    /// Available starting in standard 2.0
     /// </summary>
     public class InvalidEnumArgumentException : ArgumentException
     {
@@ -224,23 +128,5 @@ namespace PdfSharpCore
             : base(message, innerException)
         { }
     }
-
-    //public class FileNotFoundException : Exception
-    //{
-    //  public FileNotFoundException()
-    //  { }
-
-    //  public FileNotFoundException(string message)
-    //    : base(message)
-    //  { }
-
-    //  public FileNotFoundException(string message, string path)
-    //    : base(message + "/" + path)
-    //  { }
-
-    //  public FileNotFoundException(string message, Exception innerException)
-    //    : base(message, innerException)
-    //  { }
-    //}
 }
 #endif


### PR DESCRIPTION
I cleaned up the compatibility classes and attributes in AgHacks.cs, assuming that .net standard 1.3 is currently the lowest supported version. This removes any compatibility hacks from the .net standard 2.0 build.

This fixes #102, #106 and #76 (or at least it should)

It builds and all the tests pass, I'm not familiar with what other kind of testing is required to make sure all supported versions work well with this change.


Maybe @max-brightspark knows something about this? He changed the IConvertible implementation in 2018.
