### PR TITLE
Remove references to pdfsharpcore.com and pdfsharpcore.net

### DIFF
--- a/MigraDocCore.DocumentObjectModel/ProductVersionInfo.cs
+++ b/MigraDocCore.DocumentObjectModel/ProductVersionInfo.cs
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2001-2009 empira Software GmbH, Cologne (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://www.migradoc.com
 // http://sourceforge.net/projects/pdfsharp
 //

--- a/MigraDocCore.DocumentObjectModel/ProductVersionInfo.cs
+++ b/MigraDocCore.DocumentObjectModel/ProductVersionInfo.cs
@@ -62,7 +62,7 @@ namespace MigraDoc
     /// <summary>
     /// The home page of this product.
     /// </summary>
-    public const string Url = "www.migradoc.com";
+    public const string Url = "https://github.com/ststeiger/PdfSharpCore";
 
     /// <summary>
     /// </summary>
@@ -160,21 +160,21 @@ namespace MigraDoc
     /// Nuspec Doc: A URL for the home page of the package.
     /// </summary>
     /// <remarks>
-    /// http://www.PdfSharpCore.net/NuGetPackage_PDFsharp-MigraDoc-GDI.ashx
-    /// http://www.PdfSharpCore.net/NuGetPackage_PDFsharp-MigraDoc-WPF.ashx
+    /// http://www.PdfSharp.net/NuGetPackage_PDFsharp-MigraDoc-GDI.ashx
+    /// http://www.PdfSharp.net/NuGetPackage_PDFsharp-MigraDoc-WPF.ashx
     /// </remarks>
-    public const string NuGetProjectUrl = "http://www.PdfSharpCore.net/";
+    public const string NuGetProjectUrl = "https://www.nuget.org/packages/MigraDocCore.DocumentObjectModel/";
 
     /// <summary>
     /// Nuspec Doc: A URL for the image to use as the icon for the package in the Manage NuGet Packages
     /// dialog box. This should be a 32x32-pixel .png file that has a transparent background.
     /// </summary>
-    public const string NuGetIconUrl = "http://www.PdfSharpCore.net/resources/MigraDoc-Logo-32x32.png";
+    public const string NuGetIconUrl = "http://www.PdfSharp.net/resources/MigraDoc-Logo-32x32.png";
 
     /// <summary>
     /// Nuspec Doc: A link to the license that the package is under.
     /// </summary>                  
-    public const string NuGetLicenseUrl = "http://www.PdfSharpCore.net/MigraDoc_License.ashx";
+    public const string NuGetLicenseUrl = "https://github.com/ststeiger/PdfSharpCore";
 
     /// <summary>
     /// Nuspec Doc: A Boolean value that specifies whether the client needs to ensure that the package license (described by licenseUrl) is accepted before the package is installed.

--- a/PdfSharpCore/!internal/Configuration.cs
+++ b/PdfSharpCore/!internal/Configuration.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/BarCode.cs
+++ b/PdfSharpCore/Drawing.BarCodes/BarCode.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/BarCodeRenderInfo.cs
+++ b/PdfSharpCore/Drawing.BarCodes/BarCodeRenderInfo.cs
@@ -6,7 +6,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/PdfSharpCore/Drawing.BarCodes/BcgSR.cs
+++ b/PdfSharpCore/Drawing.BarCodes/BcgSR.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/Code2of5Interleaved.cs
+++ b/PdfSharpCore/Drawing.BarCodes/Code2of5Interleaved.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/Code3of9Standard.cs
+++ b/PdfSharpCore/Drawing.BarCodes/Code3of9Standard.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/CodeBase.cs
+++ b/PdfSharpCore/Drawing.BarCodes/CodeBase.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/CodeDataMatrix.cs
+++ b/PdfSharpCore/Drawing.BarCodes/CodeDataMatrix.cs
@@ -6,7 +6,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/CodeOmr.cs
+++ b/PdfSharpCore/Drawing.BarCodes/CodeOmr.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/DataMatrixImage.opensource.cs
+++ b/PdfSharpCore/Drawing.BarCodes/DataMatrixImage.opensource.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -55,7 +55,7 @@ namespace PdfSharpCore.Drawing.BarCodes
     /// Important note for OpenSource version of PDFsharp:
     ///   The generated image object only contains random data.
     ///   If you need the correct implementation as defined in the ISO/IEC 16022:2000 specification,
-    ///   please contact empira Software GmbH via www.PdfSharpCore.com.
+    ///   please contact empira Software GmbH via www.PdfSharp.com.
     /// </summary>
     internal class DataMatrixImage
     {

--- a/PdfSharpCore/Drawing.BarCodes/MatrixCode.cs
+++ b/PdfSharpCore/Drawing.BarCodes/MatrixCode.cs
@@ -6,7 +6,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/OmrData.cs
+++ b/PdfSharpCore/Drawing.BarCodes/OmrData.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/ThickThinBarcodeRenderer.cs
+++ b/PdfSharpCore/Drawing.BarCodes/ThickThinBarcodeRenderer.cs
@@ -6,7 +6,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/PdfSharpCore/Drawing.BarCodes/enums/AnchorType.cs
+++ b/PdfSharpCore/Drawing.BarCodes/enums/AnchorType.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/enums/CodeDirection.cs
+++ b/PdfSharpCore/Drawing.BarCodes/enums/CodeDirection.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/enums/CodeType.cs
+++ b/PdfSharpCore/Drawing.BarCodes/enums/CodeType.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/enums/DataMatrixEncoding.cs
+++ b/PdfSharpCore/Drawing.BarCodes/enums/DataMatrixEncoding.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/enums/MarkDistance.cs
+++ b/PdfSharpCore/Drawing.BarCodes/enums/MarkDistance.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.BarCodes/enums/TextLocation.cs
+++ b/PdfSharpCore/Drawing.BarCodes/enums/TextLocation.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.Internal/IImageImporter.cs
+++ b/PdfSharpCore/Drawing.Internal/IImageImporter.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.Internal/ImageImporter.cs
+++ b/PdfSharpCore/Drawing.Internal/ImageImporter.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.Internal/ImageImporterBmp.cs
+++ b/PdfSharpCore/Drawing.Internal/ImageImporterBmp.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.Internal/ImageImporterJpeg.cs
+++ b/PdfSharpCore/Drawing.Internal/ImageImporterJpeg.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.Internal/ImageImporterRoot.cs
+++ b/PdfSharpCore/Drawing.Internal/ImageImporterRoot.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.Layout/XTextFormatter.cs
+++ b/PdfSharpCore/Drawing.Layout/XTextFormatter.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.Layout/enums/XParagraphAlignment.cs
+++ b/PdfSharpCore/Drawing.Layout/enums/XParagraphAlignment.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.Pdf/PdfGraphicsState.cs
+++ b/PdfSharpCore/Drawing.Pdf/PdfGraphicsState.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.Pdf/XGraphicsPdfRenderer.cs
+++ b/PdfSharpCore/Drawing.Pdf/XGraphicsPdfRenderer.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.Pdf/enums/DirtyFlags.cs
+++ b/PdfSharpCore/Drawing.Pdf/enums/DirtyFlags.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing.Pdf/enums/StreamMode.cs
+++ b/PdfSharpCore/Drawing.Pdf/enums/StreamMode.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/CoreGraphicsPath.cs
+++ b/PdfSharpCore/Drawing/CoreGraphicsPath.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/FontFamilyCache.cs
+++ b/PdfSharpCore/Drawing/FontFamilyCache.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/FontFamilyInternal.cs
+++ b/PdfSharpCore/Drawing/FontFamilyInternal.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/FontHelper.cs
+++ b/PdfSharpCore/Drawing/FontHelper.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/GeometryHelper.cs
+++ b/PdfSharpCore/Drawing/GeometryHelper.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/GraphicsStateStack.cs
+++ b/PdfSharpCore/Drawing/GraphicsStateStack.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/IXGraphicsRenderer.cs
+++ b/PdfSharpCore/Drawing/IXGraphicsRenderer.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/ImageHelper.cs
+++ b/PdfSharpCore/Drawing/ImageHelper.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/InternalGraphicsState.cs
+++ b/PdfSharpCore/Drawing/InternalGraphicsState.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/PdfFontOptions.cs
+++ b/PdfSharpCore/Drawing/PdfFontOptions.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XBaseGradientBrush.cs
+++ b/PdfSharpCore/Drawing/XBaseGradientBrush.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XBitmapDecoder.cs
+++ b/PdfSharpCore/Drawing/XBitmapDecoder.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XBitmapEncoder.cs
+++ b/PdfSharpCore/Drawing/XBitmapEncoder.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XBitmapImage.cs
+++ b/PdfSharpCore/Drawing/XBitmapImage.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XBitmapSource.cs
+++ b/PdfSharpCore/Drawing/XBitmapSource.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XBrush.cs
+++ b/PdfSharpCore/Drawing/XBrush.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XBrushes.cs
+++ b/PdfSharpCore/Drawing/XBrushes.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XColor.cs
+++ b/PdfSharpCore/Drawing/XColor.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XColorResourceManager.cs
+++ b/PdfSharpCore/Drawing/XColorResourceManager.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XColors.cs
+++ b/PdfSharpCore/Drawing/XColors.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XConvert.cs
+++ b/PdfSharpCore/Drawing/XConvert.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XFont.cs
+++ b/PdfSharpCore/Drawing/XFont.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XFontFamily.cs
+++ b/PdfSharpCore/Drawing/XFontFamily.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XFontMetrics.cs
+++ b/PdfSharpCore/Drawing/XFontMetrics.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XFontSource.cs
+++ b/PdfSharpCore/Drawing/XFontSource.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XFontStretch.cs
+++ b/PdfSharpCore/Drawing/XFontStretch.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XFontWeight.cs
+++ b/PdfSharpCore/Drawing/XFontWeight.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XFontWeights.cs
+++ b/PdfSharpCore/Drawing/XFontWeights.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XForm.cs
+++ b/PdfSharpCore/Drawing/XForm.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XGlyphTypeface.cs
+++ b/PdfSharpCore/Drawing/XGlyphTypeface.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XGraphics.cs
+++ b/PdfSharpCore/Drawing/XGraphics.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XGraphicsContainer.cs
+++ b/PdfSharpCore/Drawing/XGraphicsContainer.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XGraphicsPath.cs
+++ b/PdfSharpCore/Drawing/XGraphicsPath.cs
@@ -881,7 +881,7 @@ namespace PdfSharpCore.Drawing
                 Lock.EnterGdiPlus();
                 // If rect is empty GDI+ removes the rect from the path.
                 // This is not intended if the path is used for clipping.
-                // See http://forum.PdfSharpCore.net/viewtopic.php?p=9433#p9433
+                // See http://forum.PdfSharp.net/viewtopic.php?p=9433#p9433
                 // _gdipPath.AddRectangle(rect.ToRectangleF());
 
                 // Draw the rectangle manually.

--- a/PdfSharpCore/Drawing/XGraphicsPath.cs
+++ b/PdfSharpCore/Drawing/XGraphicsPath.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XGraphicsPathInternals.cs
+++ b/PdfSharpCore/Drawing/XGraphicsPathInternals.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XGraphicsPathItem.cs
+++ b/PdfSharpCore/Drawing/XGraphicsPathItem.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XGraphicsState.cs
+++ b/PdfSharpCore/Drawing/XGraphicsState.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XImage.cs
+++ b/PdfSharpCore/Drawing/XImage.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XImageFormat.cs
+++ b/PdfSharpCore/Drawing/XImageFormat.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XKnownColorTable.cs
+++ b/PdfSharpCore/Drawing/XKnownColorTable.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XLinearGradientBrush.cs
+++ b/PdfSharpCore/Drawing/XLinearGradientBrush.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XMatrix.cs
+++ b/PdfSharpCore/Drawing/XMatrix.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XPdfForm.cs
+++ b/PdfSharpCore/Drawing/XPdfForm.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XPen.cs
+++ b/PdfSharpCore/Drawing/XPen.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XPens.cs
+++ b/PdfSharpCore/Drawing/XPens.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XPoint.cs
+++ b/PdfSharpCore/Drawing/XPoint.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XPrivateFontCollection.cs
+++ b/PdfSharpCore/Drawing/XPrivateFontCollection.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XRadialGradientBrush.cs
+++ b/PdfSharpCore/Drawing/XRadialGradientBrush.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XRect.cs
+++ b/PdfSharpCore/Drawing/XRect.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XSize.cs
+++ b/PdfSharpCore/Drawing/XSize.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XSolidBrush.cs
+++ b/PdfSharpCore/Drawing/XSolidBrush.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XStringFormat.cs
+++ b/PdfSharpCore/Drawing/XStringFormat.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XStringFormats.cs
+++ b/PdfSharpCore/Drawing/XStringFormats.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XTypeface.cs
+++ b/PdfSharpCore/Drawing/XTypeface.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XUnit.cs
+++ b/PdfSharpCore/Drawing/XUnit.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/XVector.cs
+++ b/PdfSharpCore/Drawing/XVector.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/PathStart.cs
+++ b/PdfSharpCore/Drawing/enums/PathStart.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XColorSpace.cs
+++ b/PdfSharpCore/Drawing/enums/XColorSpace.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XCombineMode.cs
+++ b/PdfSharpCore/Drawing/enums/XCombineMode.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XDashStyle.cs
+++ b/PdfSharpCore/Drawing/enums/XDashStyle.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XFillMode.cs
+++ b/PdfSharpCore/Drawing/enums/XFillMode.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XFontStyle.cs
+++ b/PdfSharpCore/Drawing/enums/XFontStyle.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XGdiFontStyle.cs
+++ b/PdfSharpCore/Drawing/enums/XGdiFontStyle.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XGraphicRenderTarget.cs
+++ b/PdfSharpCore/Drawing/enums/XGraphicRenderTarget.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XGraphicsPathItemType.cs
+++ b/PdfSharpCore/Drawing/enums/XGraphicsPathItemType.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XGraphicsPdfPageOptions.cs
+++ b/PdfSharpCore/Drawing/enums/XGraphicsPdfPageOptions.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XGraphicsUnit.cs
+++ b/PdfSharpCore/Drawing/enums/XGraphicsUnit.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XKnownColor.cs
+++ b/PdfSharpCore/Drawing/enums/XKnownColor.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XLineAlignment.cs
+++ b/PdfSharpCore/Drawing/enums/XLineAlignment.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XLineCap.cs
+++ b/PdfSharpCore/Drawing/enums/XLineCap.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XLineJoin.cs
+++ b/PdfSharpCore/Drawing/enums/XLineJoin.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XLinearGradientMode.cs
+++ b/PdfSharpCore/Drawing/enums/XLinearGradientMode.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XMatrixOrder.cs
+++ b/PdfSharpCore/Drawing/enums/XMatrixOrder.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XPageDirection.cs
+++ b/PdfSharpCore/Drawing/enums/XPageDirection.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XSmoothingMode.cs
+++ b/PdfSharpCore/Drawing/enums/XSmoothingMode.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XStringAlignment.cs
+++ b/PdfSharpCore/Drawing/enums/XStringAlignment.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XStyleSimulations.cs
+++ b/PdfSharpCore/Drawing/enums/XStyleSimulations.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Drawing/enums/XSweepDirection.cs
+++ b/PdfSharpCore/Drawing/enums/XSweepDirection.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Internal/Calc.cs
+++ b/PdfSharpCore/Internal/Calc.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Internal/ColorHelper.cs
+++ b/PdfSharpCore/Internal/ColorHelper.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Internal/Diagnostics.cs
+++ b/PdfSharpCore/Internal/Diagnostics.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Internal/DiagnosticsHelper.cs
+++ b/PdfSharpCore/Internal/DiagnosticsHelper.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Internal/DoubleUtil.cs
+++ b/PdfSharpCore/Internal/DoubleUtil.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Internal/Lock.cs
+++ b/PdfSharpCore/Internal/Lock.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Internal/NativeMethods.cs
+++ b/PdfSharpCore/Internal/NativeMethods.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Internal/TokenizerHelper.cs
+++ b/PdfSharpCore/Internal/TokenizerHelper.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/EntryInfoAttribute.cs
+++ b/PdfSharpCore/Pdf/EntryInfoAttribute.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/KeysBase.cs
+++ b/PdfSharpCore/Pdf/KeysBase.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/KeysMeta.cs
+++ b/PdfSharpCore/Pdf/KeysMeta.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfArray.cs
+++ b/PdfSharpCore/Pdf/PdfArray.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfBoolean.cs
+++ b/PdfSharpCore/Pdf/PdfBoolean.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfBooleanObject.cs
+++ b/PdfSharpCore/Pdf/PdfBooleanObject.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfCustomValue.cs
+++ b/PdfSharpCore/Pdf/PdfCustomValue.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfCustomValues.cs
+++ b/PdfSharpCore/Pdf/PdfCustomValues.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfDate.cs
+++ b/PdfSharpCore/Pdf/PdfDate.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfDictionary.cs
+++ b/PdfSharpCore/Pdf/PdfDictionary.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfDocument.cs
+++ b/PdfSharpCore/Pdf/PdfDocument.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfDocumentInformation.cs
+++ b/PdfSharpCore/Pdf/PdfDocumentInformation.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfDocumentOptions.cs
+++ b/PdfSharpCore/Pdf/PdfDocumentOptions.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfDocumentSettings.cs
+++ b/PdfSharpCore/Pdf/PdfDocumentSettings.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfInteger.cs
+++ b/PdfSharpCore/Pdf/PdfInteger.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfIntegerObject.cs
+++ b/PdfSharpCore/Pdf/PdfIntegerObject.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfItem.cs
+++ b/PdfSharpCore/Pdf/PdfItem.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfLiteral.cs
+++ b/PdfSharpCore/Pdf/PdfLiteral.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfName.cs
+++ b/PdfSharpCore/Pdf/PdfName.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-20165 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfNameObject.cs
+++ b/PdfSharpCore/Pdf/PdfNameObject.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfNull.cs
+++ b/PdfSharpCore/Pdf/PdfNull.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfNullObject.cs
+++ b/PdfSharpCore/Pdf/PdfNullObject.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfNumber.cs
+++ b/PdfSharpCore/Pdf/PdfNumber.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfNumberObject.cs
+++ b/PdfSharpCore/Pdf/PdfNumberObject.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfObject.cs
+++ b/PdfSharpCore/Pdf/PdfObject.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfObjectID.cs
+++ b/PdfSharpCore/Pdf/PdfObjectID.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfOutline.cs
+++ b/PdfSharpCore/Pdf/PdfOutline.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfOutlineCollection.cs
+++ b/PdfSharpCore/Pdf/PdfOutlineCollection.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfPage.cs
+++ b/PdfSharpCore/Pdf/PdfPage.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfPages.cs
+++ b/PdfSharpCore/Pdf/PdfPages.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfReal.cs
+++ b/PdfSharpCore/Pdf/PdfReal.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfRealObject.cs
+++ b/PdfSharpCore/Pdf/PdfRealObject.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfRectangle.cs
+++ b/PdfSharpCore/Pdf/PdfRectangle.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfReferenceTable.cs
+++ b/PdfSharpCore/Pdf/PdfReferenceTable.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfString.cs
+++ b/PdfSharpCore/Pdf/PdfString.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfStringObject.cs
+++ b/PdfSharpCore/Pdf/PdfStringObject.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfUInteger.cs
+++ b/PdfSharpCore/Pdf/PdfUInteger.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfUIntegerObject.cs
+++ b/PdfSharpCore/Pdf/PdfUIntegerObject.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/PdfViewerPreferences.cs
+++ b/PdfSharpCore/Pdf/PdfViewerPreferences.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/TrimMargins.cs
+++ b/PdfSharpCore/Pdf/TrimMargins.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/enums/DocumentState.cs
+++ b/PdfSharpCore/Pdf/enums/DocumentState.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/enums/PdfColorMode.cs
+++ b/PdfSharpCore/Pdf/enums/PdfColorMode.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/enums/PdfCustomValueCompression.cs
+++ b/PdfSharpCore/Pdf/enums/PdfCustomValueCompression.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/enums/PdfFlateEncodeMode.cs
+++ b/PdfSharpCore/Pdf/enums/PdfFlateEncodeMode.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/enums/PdfFontEncoding.cs
+++ b/PdfSharpCore/Pdf/enums/PdfFontEncoding.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/enums/PdfOutlineStyle.cs
+++ b/PdfSharpCore/Pdf/enums/PdfOutlineStyle.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/enums/PdfPageDestinationType.cs
+++ b/PdfSharpCore/Pdf/enums/PdfPageDestinationType.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/enums/PdfPageLayout.cs
+++ b/PdfSharpCore/Pdf/enums/PdfPageLayout.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/enums/PdfPageMode.cs
+++ b/PdfSharpCore/Pdf/enums/PdfPageMode.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/enums/PdfReadingDirection.cs
+++ b/PdfSharpCore/Pdf/enums/PdfReadingDirection.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/enums/PdfTextStringEncoding.cs
+++ b/PdfSharpCore/Pdf/enums/PdfTextStringEncoding.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/Pdf/enums/PdfUseFlateDecoderForJpegImages.cs
+++ b/PdfSharpCore/Pdf/enums/PdfUseFlateDecoderForJpegImages.cs
@@ -5,7 +5,7 @@
 //
 // Copyright (c) 2005-2016 empira Software GmbH, Cologne Area (Germany)
 //
-// http://www.PdfSharpCore.com
+// http://www.PdfSharp.com
 // http://sourceforge.net/projects/pdfsharp
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/PdfSharpCore/root/ProductVersionInfo.cs
+++ b/PdfSharpCore/root/ProductVersionInfo.cs
@@ -70,7 +70,7 @@ namespace PdfSharpCore
         /// <summary>
         /// The home page of this product.
         /// </summary>
-        public const string Url = "www.PdfSharpCore.com";
+        public const string Url = "https://github.com/ststeiger/PdfSharpCore";
 
         /// <summary>
         /// Unused.
@@ -200,13 +200,13 @@ namespace PdfSharpCore
         /// http://www.PdfSharpCore.net/NuGetPackage_PDFsharp-GDI.ashx
         /// http://www.PdfSharpCore.net/NuGetPackage_PDFsharp-WPF.ashx
         /// </remarks>
-        public const string NuGetProjectUrl = "www.PdfSharpCore.net";
+        public const string NuGetProjectUrl = "https://www.nuget.org/packages/PdfSharpCore/";
 
         /// <summary>
         /// Nuspec Doc: A URL for the image to use as the icon for the package in the Manage NuGet Packages
         /// dialog box. This should be a 32x32-pixel .png file that has a transparent background.
         /// </summary>
-        public const string NuGetIconUrl = "http://www.PdfSharpCore.net/resources/PDFsharp-Logo-32x32.png";
+        public const string NuGetIconUrl = "http://www.PdfSharp.net/resources/PDFsharp-Logo-32x32.png";
 
         /// <summary>
         /// Nuspec Doc: A link to the license that the package is under.


### PR DESCRIPTION
In fixing #101, I discovered quite a few references to pdfsharpcore.com and pdfsharpcore.net. Since both of these domains are for sale, I would recommend removing any references (think: If some one buys those and links to something objectionable)

I believe most of these are due to automatic search and replace at the inital fork. 

The most relevant parts are the ProductVersionInfo.cs files. These show up on the output of the library.

I replaced the copyright notices with the original Url, and the project Urls with the git repo url.