### PR TITLE
Fixes FontResolver for Linux based system. passes Tests on Linux system

### DIFF
--- a/PdfSharpCore.Test/PdfSharpCore.Test.csproj
+++ b/PdfSharpCore.Test/PdfSharpCore.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
tests were failing on my default Arch Linux system. As I looked through code, I see that many fonts would be missing, even if they were in the correct folder. 

problems I found:

- font resolver was only scanning one static font directory. My default folder was missed and so was my user fonts folder (Linux default font configuration could have fonts in many folders which are configured in /etc/fonts/fonts.conf)
- files in Linux are case sensitive, so the font resolver (which used Directory.GetFiles was not resolving all fonts

proposed solutions:

- parse default Linux fonts configuration file and search all configured fonts folders
- enumerate all files and use a case insensitive regular expression
