### PR TITLE
Update pipeline to use new dotnetcore SDK docker repo

### DIFF
--- a/.ci/tasks/build.yaml
+++ b/.ci/tasks/build.yaml
@@ -3,8 +3,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: mcr.microsoft.com/dotnet/core/sdk
-    tag: 3.1
+    repository: mcr.microsoft.com/dotnet/sdk
+    tag: 5.0.103-alpine3.12-amd64
 inputs:
 - name: source
 params:

--- a/.ci/tasks/build.yaml
+++ b/.ci/tasks/build.yaml
@@ -15,4 +15,15 @@ run:
   - -c
   - |
     cd "source/${PROJECT}"
+
+    # For some reason, dotnet build fails with
+    # /usr/share/dotnet/sdk/5.0.103/Roslyn/Microsoft.CSharp.Core.targets(71,5): error MSB6004: The specified task executable location "/rootfs/usr/share/dotnet/dotnet" is invalid. [/tmp/build/6da1d659/source/PdfSharpCore/PdfSharpCore.csproj]
+    # ...
+    # Microsoft.Build.BackEnd.NodeFailedToLaunchException: No such file or directory
+    #
+    # I can't find why "/rootfs" is prepended on concourse but works fine in the same docker image running in other environments
+    # Hack is to create this directory structure for now and symlink dotnet binary there
+    mkdir -p /rootfs/usr/share/dotnet/
+    ln -s /usr/share/dotnet/dotnet /rootfs/usr/share/dotnet/dotnet
+
     dotnet build /p:GeneratePackageOnBuild=False -c Release "${PROJECT}.csproj"

--- a/.ci/tasks/publish-nugget.yaml
+++ b/.ci/tasks/publish-nugget.yaml
@@ -22,6 +22,17 @@ run:
   - |
     VERSION=$(cat version/version)
     cd "source/${PROJECT}"
+
+    # For some reason, dotnet build fails with
+    # /usr/share/dotnet/sdk/5.0.103/Roslyn/Microsoft.CSharp.Core.targets(71,5): error MSB6004: The specified task executable location "/rootfs/usr/share/dotnet/dotnet" is invalid. [/tmp/build/6da1d659/source/PdfSharpCore/PdfSharpCore.csproj]
+    # ...
+    # Microsoft.Build.BackEnd.NodeFailedToLaunchException: No such file or directory
+    #
+    # I can't find why "/rootfs" is prepended on concourse but works fine in the same docker image running in other environments
+    # Hack is to create this directory structure for now and symlink dotnet binary there
+    mkdir -p /rootfs/usr/share/dotnet/
+    ln -s /usr/share/dotnet/dotnet /rootfs/usr/share/dotnet/dotnet
+
     dotnet build /p:GeneratePackageOnBuild=False /p:AssemblyVersion=${VERSION} /p:FileVersion=${VERSION} -c Release "${PROJECT}.csproj"
     dotnet pack /p:PackageVersion=${VERSION} /p:PackageTags="${NUGGET_TAGS} $(cat ../.git/ref)" /p:PackageReleaseNotes="$(sed -e 's/;/ /g' -e 's/,/ /g' ../.git/commit_message)" --no-restore -c Release -o out "${PROJECT}.csproj"
     dotnet nuget push out/${PROJECT}.${VERSION}.nupkg -k ${NUGGET_API_KEY} -s https://api.nuget.org/v3/index.json

--- a/.ci/tasks/publish-nugget.yaml
+++ b/.ci/tasks/publish-nugget.yaml
@@ -3,8 +3,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: mcr.microsoft.com/dotnet/core/sdk
-    tag: 3.1
+    repository: mcr.microsoft.com/dotnet/sdk
+    tag: 5.0.103-alpine3.12-amd64
 inputs:
 - name: source
 - name: version

--- a/PdfSharpCore/.ci/pipeline.yml
+++ b/PdfSharpCore/.ci/pipeline.yml
@@ -11,7 +11,7 @@ get_source_publish: &get_source_publish
   <<: *get_source
   trigger: false
   passed:
-  - TestBuild
+  - test-build
 
 get_version: &get_version
   get: version
@@ -63,7 +63,7 @@ resources:
 jobs:
 
 # Would be replace with proper Unit/Integration tests
-- name: TestBuild
+- name: test-build
   <<: *job
   plan:
   - <<: *get_source
@@ -73,7 +73,7 @@ jobs:
     params:
       <<: *project
 
-- name: PublishPatch
+- name: publish-patch
   <<: *job
   plan:
   - in_parallel:
@@ -86,7 +86,7 @@ jobs:
   - <<: *put_version
   - <<: *task_publish_nugget
 
-- name: PublishMinor
+- name: publish-minor
   <<: *job
   plan:
   - in_parallel:
@@ -98,7 +98,7 @@ jobs:
   - <<: *put_version
   - <<: *task_publish_nugget
 
-- name: PublishMajor
+- name: publish-major
   <<: *job
   plan:
   - in_parallel:


### PR DESCRIPTION
The docker repo for dotnetcore docker images was renamed, please see [here](https://github.com/dotnet/dotnet-docker/issues/2375) for more info. This PR updates the images used in the pipeline to use the latest version of the SDK.

For some reason, the new SDK images resolve `DOTNET_HOST_PATH` to `/rootfs/usr/share/dotnet/dotnet` instead of `/usr/share/dotnet/dotnet` breaking the pipeline. This is however correctly resolved when running the same image on a mac. So this seems to be related to the docker daemon host. This PR also includes a "hack" to fix this, it would be removed once a solution is found