### PR TITLE
Fix descent sign for ParagraphRenderer

### DIFF
--- a/MigraDocCore.Rendering/MigraDoc.Rendering/FontHandler.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/FontHandler.cs
@@ -151,7 +151,7 @@ namespace MigraDocCore.Rendering
 
     internal static XUnit GetDescent(XFont font)
     {
-      XUnit descent = -font.Metrics.Descent;
+      XUnit descent = font.Metrics.Descent;
       descent *= font.Size;
       descent /= font.FontFamily.GetEmHeight(font.Style);
       return descent;


### PR DESCRIPTION
It appears there shouldn't be minus here:
https://github.com/ststeiger/PdfSharpCore/blob/543ab752370b3281f040c32f27489f9ab98f280b/MigraDocCore.Rendering/MigraDoc.Rendering/FontHandler.cs#L152-L158

The only places where that function is used are:
https://github.com/ststeiger/PdfSharpCore/blob/543ab752370b3281f040c32f27489f9ab98f280b/MigraDocCore.Rendering/MigraDoc.Rendering/ParagraphRenderer.cs#L1173-L1196
and
https://github.com/ststeiger/PdfSharpCore/blob/543ab752370b3281f040c32f27489f9ab98f280b/MigraDocCore.Rendering/MigraDoc.Rendering/ParagraphRenderer.cs#L2258-L2271
and they seem to expect positive number. Original MigraDoc code doesn't have minus either.

That should fix  #143