### PR TITLE
Use project reference for dependency

### DIFF
--- a/MigraDocCore.Rendering/MigraDocCore.Rendering.csproj
+++ b/MigraDocCore.Rendering/MigraDocCore.Rendering.csproj
@@ -25,7 +25,7 @@ MigraDocCore.Rendering was ported from MigraDoc version 1.32</Description>
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
-    <PackageReference Include="MigraDocCore.DocumentObjectModel" Version="0.1.2" />
+    <ProjectReference Include="..\MigraDocCore.DocumentObjectModel\MigraDocCore.DocumentObjectModel.csproj" />
     <ProjectReference Include="..\PdfSharpCore.Charting\PdfSharpCore.Charting.csproj" />
     <ProjectReference Include="..\PdfSharpCore\PdfSharpCore.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Switch dependency on `MigraDocCore.DocumentObjectModel` in `MigraDocCore.Rendering` to project reference.

Extends #182