### PR TITLE
Table performance improvements

### DIFF
--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Tables/Cell.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Tables/Cell.cs
@@ -338,22 +338,22 @@ namespace MigraDocCore.DocumentObjectModel.Tables
         /// </summary>
         public int MergeRight
         {
-            get { return this.mergeRight.Value; }
-            set { this.mergeRight.Value = value; }
+            get { return this.mergeRight ?? 0; }
+            set { this.mergeRight = value; }
         }
         [DV]
-        internal NInt mergeRight = NInt.NullValue;
+        internal int? mergeRight;
 
         /// <summary>
         /// Gets or sets the number of cells to be merged down.
         /// </summary>
         public int MergeDown
         {
-            get { return this.mergeDown.Value; }
-            set { this.mergeDown.Value = value; }
+            get { return this.mergeDown ?? 0; }
+            set { this.mergeDown = value; }
         }
         [DV]
-        internal NInt mergeDown = NInt.NullValue;
+        internal int? mergeDown;
 
         /// <summary>
         /// Gets the collection of document objects that defines the cell.
@@ -405,10 +405,10 @@ namespace MigraDocCore.DocumentObjectModel.Tables
             if (!this.IsNull("Format"))
                 this.format.Serialize(serializer, "Format", null);
 
-            if (!this.mergeDown.IsNull)
+            if (this.mergeDown.HasValue)
                 serializer.WriteSimpleAttribute("MergeDown", this.MergeDown);
 
-            if (!this.mergeRight.IsNull)
+            if (this.mergeRight.HasValue)
                 serializer.WriteSimpleAttribute("MergeRight", this.MergeRight);
 
             if (!this.verticalAlignment.IsNull)

--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Tables/Column.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Tables/Column.cs
@@ -117,8 +117,12 @@ namespace MigraDocCore.DocumentObjectModel.Tables
       {
         if (!index.HasValue)
         {
-          Columns clms = this.Parent as Columns;
-          SetValue("Index", index = clms.IndexOf(this));
+          Columns clms = (Columns)Parent;
+          // One for all and all for one.
+          for (int i = 0; i < clms.Count; ++i)
+          {
+            clms[i].index = i;
+          }
         }
         return index ?? 0;
       }

--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Tables/Column.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Tables/Column.cs
@@ -115,16 +115,16 @@ namespace MigraDocCore.DocumentObjectModel.Tables
     {
       get
       {
-        if (IsNull("Index"))
+        if (!index.HasValue)
         {
           Columns clms = this.Parent as Columns;
-          SetValue("Index", clms.IndexOf(this));
+          SetValue("Index", index = clms.IndexOf(this));
         }
-        return index;
+        return index ?? 0;
       }
     }
     [DV]
-    internal NInt index = NInt.NullValue;
+    internal int? index;
 
     /// <summary>
     /// Gets a cell by its row index. The first cell has index 0.
@@ -134,7 +134,7 @@ namespace MigraDocCore.DocumentObjectModel.Tables
       get
       {
         //Check.ArgumentOutOfRange(index >= 0 && index < table.Rows.Count, "index");
-        return Table.Rows[index][this.index];
+        return Table.Rows[index][this.index ?? 0];
       }
     }
 
@@ -230,11 +230,11 @@ namespace MigraDocCore.DocumentObjectModel.Tables
     /// </summary>
     public int KeepWith
     {
-      get { return this.keepWith.Value; }
-      set { this.keepWith.Value = value; }
+      get { return this.keepWith ?? 0; }
+      set { this.keepWith = value; }
     }
     [DV]
-    internal NInt keepWith = NInt.NullValue;
+    internal int? keepWith;
 
     /// <summary>
     /// Gets or sets a value which define whether the column is a header.
@@ -309,7 +309,7 @@ namespace MigraDocCore.DocumentObjectModel.Tables
       if (!this.width.IsNull)
         serializer.WriteSimpleAttribute("Width", this.Width);
 
-      if (!this.keepWith.IsNull)
+      if (this.keepWith.HasValue)
         serializer.WriteSimpleAttribute("KeepWith", this.KeepWith);
 
       if (!this.IsNull("Borders"))

--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Tables/Row.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Tables/Row.cs
@@ -124,9 +124,9 @@ namespace MigraDocCore.DocumentObjectModel.Tables
         if (!index.HasValue)
         {
           Rows rws = this.parent as Rows;
-          SetValue("Index", rws.IndexOf(this));
+          SetValue("Index", index = rws.IndexOf(this));
         }
-        return index.Value;
+        return index ?? 0;
       }
     }
     [DV]
@@ -286,11 +286,11 @@ namespace MigraDocCore.DocumentObjectModel.Tables
     /// </summary>
     public int KeepWith
     {
-      get { return this.keepWith.Value; }
-      set { this.keepWith.Value = value; }
+      get { return this.keepWith ?? 0; }
+      set { this.keepWith = value; }
     }
     [DV]
-    internal NInt keepWith = NInt.NullValue;
+    internal int? keepWith;
 
     /// <summary>
     /// Gets the Cells collection of the table.
@@ -360,7 +360,7 @@ namespace MigraDocCore.DocumentObjectModel.Tables
       if (!this.verticalAlignment.IsNull)
         serializer.WriteSimpleAttribute("VerticalAlignment", this.VerticalAlignment);
 
-      if (!this.keepWith.IsNull)
+      if (this.keepWith.HasValue)
         serializer.WriteSimpleAttribute("KeepWith", this.KeepWith);
 
       //Borders & Shading

--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Tables/Row.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Tables/Row.cs
@@ -121,16 +121,16 @@ namespace MigraDocCore.DocumentObjectModel.Tables
     {
       get
       {
-        if (IsNull("index"))
+        if (!index.HasValue)
         {
           Rows rws = this.parent as Rows;
           SetValue("Index", rws.IndexOf(this));
         }
-        return index;
+        return index.Value;
       }
     }
     [DV]
-    internal NInt index = NInt.NullValue;
+    internal int? index;
 
     /// <summary>
     /// Gets a cell by its column index. The first cell has index 0.

--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Tables/Row.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Tables/Row.cs
@@ -123,8 +123,12 @@ namespace MigraDocCore.DocumentObjectModel.Tables
       {
         if (!index.HasValue)
         {
-          Rows rws = this.parent as Rows;
-          SetValue("Index", index = rws.IndexOf(this));
+          Rows rws = (Rows)parent;
+          // One for all and all for one.
+          for (int i = 0; i < rws.Count; ++i)
+          {
+            rws[i].index = i;
+          }
         }
         return index ?? 0;
       }

--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Visitors/CellComparer.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Visitors/CellComparer.cs
@@ -31,7 +31,7 @@
 #endregion
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using MigraDocCore.DocumentObjectModel.Tables;
 using MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Resources;
 
@@ -41,23 +41,21 @@ namespace MigraDocCore.DocumentObjectModel.Visitors
   /// Comparer for the cell positions within a table.
   /// It compares the cell positions from top to bottom and left to right.
   /// </summary>
-  public class CellComparer : IComparer
+  public class CellComparer : IComparer<Cell>
   {
-    public int Compare(object lhs, object rhs)
+    public int Compare(Cell lhs, Cell rhs)
     {
-      if (!(lhs is Cell))
-        throw new ArgumentException(AppResources.CompareJustCells, "lhs");
+      if (ReferenceEquals(lhs, null))
+        throw new ArgumentNullException(nameof(lhs));
 
-      if (!(rhs is Cell))
-        throw new ArgumentException(AppResources.CompareJustCells, "rhs");
+      if (ReferenceEquals(rhs, null))
+        throw new ArgumentNullException(nameof(rhs));
 
-      Cell cellLhs = lhs as Cell;
-      Cell cellRhs = rhs as Cell;
-      int rowCmpr = cellLhs.Row.Index - cellRhs.Row.Index;
+      int rowCmpr = lhs.Row.Index - rhs.Row.Index;
       if (rowCmpr != 0)
         return rowCmpr;
 
-      return cellLhs.Column.Index - cellRhs.Column.Index;
+      return lhs.Column.Index - rhs.Column.Index;
     }
   }
 }

--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Visitors/MergedCellList.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Visitors/MergedCellList.cs
@@ -189,7 +189,7 @@ namespace MigraDocCore.DocumentObjectModel.Visitors
 
       if (cell.mergeRight > 0)
       {
-        Cell rightBorderCell = cell.Table[cell.Row.Index, cell.Column.Index + cell.mergeRight];
+        Cell rightBorderCell = cell.Table[cell.Row.Index, cell.Column.Index + (cell.mergeRight ?? 0)];
         if (rightBorderCell.borders != null && rightBorderCell.borders.right != null)
           borders.Right = rightBorderCell.borders.right.Clone();
         else
@@ -198,7 +198,7 @@ namespace MigraDocCore.DocumentObjectModel.Visitors
 
       if (cell.mergeDown > 0)
       {
-        Cell bottomBorderCell = cell.Table[cell.Row.Index + cell.mergeDown, cell.Column.Index];
+        Cell bottomBorderCell = cell.Table[cell.Row.Index + (cell.mergeDown ?? 0), cell.Column.Index];
         if (bottomBorderCell.borders != null && bottomBorderCell.borders.bottom != null)
           borders.Bottom = bottomBorderCell.borders.bottom.Clone();
         else

--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Visitors/MergedCellList.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Visitors/MergedCellList.cs
@@ -32,6 +32,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using MigraDocCore.DocumentObjectModel.IO;
 using MigraDocCore.DocumentObjectModel.Tables;
 using MigraDocCore.DocumentObjectModel.Visitors;
@@ -42,49 +43,8 @@ namespace MigraDocCore.DocumentObjectModel.Visitors
   /// <summary>
   /// Represents a merged list of cells of a table.
   /// </summary>
-  public class MergedCellList : ArrayList
+  public class MergedCellList : List<Cell>
   {
-
-    /// <summary>
-    /// Enumerator that can iterate through the MergedCellList.
-    /// </summary>
-    public class Enumerator : IEnumerator
-    {
-      internal Enumerator(MergedCellList list)
-      {
-        this.list = list;
-      }
-
-      #region IEnumerator Members
-
-      public void Reset()
-      {
-        this.index = -1;
-      }
-
-      public Cell Current
-      {
-        get
-        {
-          return (Cell)this.list[this.index];
-        }
-      }
-
-      object IEnumerator.Current
-      {
-        get { return Current; }
-      }
-
-      public bool MoveNext()
-      {
-        return ++index < this.list.Count;
-      }
-      #endregion
-
-      MergedCellList list;
-      int index = -1;
-    }
-
     /// <summary>
     /// Enumeration of neighbor positions of cells in a table.
     /// </summary>
@@ -142,14 +102,6 @@ namespace MigraDocCore.DocumentObjectModel.Visitors
         }
       }
       return false;
-    }
-
-    /// <summary>
-    /// Gets the Enumerator for this list.
-    /// </summary>
-    public override IEnumerator GetEnumerator()
-    {
-      return new Enumerator(this);
     }
 
     /// <summary>

--- a/MigraDocCore.Rendering/MigraDoc.Rendering/TableFormatInfo.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/TableFormatInfo.cs
@@ -30,8 +30,11 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using MigraDocCore.DocumentObjectModel;
+using MigraDocCore.DocumentObjectModel.Tables;
 using MigraDocCore.DocumentObjectModel.Visitors;
+using PdfSharpCore.Drawing;
 
 namespace MigraDocCore.Rendering
 {
@@ -86,9 +89,9 @@ namespace MigraDocCore.Rendering
     internal int endRow = -1;
 
     internal int lastHeaderRow = -1;
-    internal SortedList formattedCells;
+    internal SortedList<Cell, FormattedCell> formattedCells;
     internal MergedCellList mergedCells;
-    internal SortedList bottomBorderMap;
-    internal SortedList connectedRowsMap;
+    internal SortedList<int, XUnit> bottomBorderMap;
+    internal SortedList<int, int> connectedRowsMap;
   }
 }

--- a/MigraDocCore.Rendering/MigraDoc.Rendering/TableRenderer.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/TableRenderer.cs
@@ -569,22 +569,27 @@ namespace MigraDocCore.Rendering
       XUnit maxBottomBorderPosition = lastPos + minMergedFormattedCell.InnerHeight;
       maxBottomBorderPosition += CalcBottomBorderWidth(minMergedCell);
 
+      // Note: Caching the indices does speed up this function for large tables greatly.
+      var minMergedCellRowIndex = minMergedCell.Row.Index;
+      var minMergedCellMergeDown = minMergedCell.MergeDown;
+      var mergedIndexPlusDown = minMergedCellRowIndex + minMergedCellMergeDown;
       foreach (Cell cell in this.mergedCells)
       {
-        if (cell.Row.Index > minMergedCell.Row.Index + minMergedCell.MergeDown)
+        var rowIndex = cell.Row.Index;
+        if (rowIndex > mergedIndexPlusDown)
           break;
 
-        if (cell.Row.Index + cell.MergeDown == minMergedCell.Row.Index + minMergedCell.MergeDown)
+        if (rowIndex + cell.MergeDown == mergedIndexPlusDown)
         {
           FormattedCell formattedCell = (FormattedCell)this.formattedCells[cell];
-          XUnit topBorderPos = (XUnit)this.bottomBorderMap[cell.Row.Index];
+          XUnit topBorderPos = (XUnit)this.bottomBorderMap[rowIndex];
           XUnit bottomBorderPos = topBorderPos + formattedCell.InnerHeight;
           bottomBorderPos += CalcBottomBorderWidth(cell);
           if (bottomBorderPos > maxBottomBorderPosition)
             maxBottomBorderPosition = bottomBorderPos;
         }
       }
-      this.bottomBorderMap.Add(minMergedCell.Row.Index + minMergedCell.MergeDown + 1, maxBottomBorderPosition);
+      this.bottomBorderMap.Add(mergedIndexPlusDown + 1, maxBottomBorderPosition);
     }
 
     /// <summary>
@@ -614,20 +619,22 @@ namespace MigraDocCore.Rendering
       Cell minCell = null;
       foreach (Cell cell in this.mergedCells)
       {
-        if (cell.Row.Index == row)
+        var rowIndex = cell.Row.Index; // Note: Taking index only once speeds up large tables.
+        if (rowIndex <= row && rowIndex + cell.MergeDown >= row)
         {
-          if (cell.MergeDown == 0)
+          if (rowIndex == row && cell.MergeDown == 0)
           {
+            // Perfect match: non-merged cell in the desired row.
             minCell = cell;
             break;
           }
-          else if (cell.MergeDown < minMerge)
+          else if (rowIndex + cell.MergeDown - row < minMerge)
           {
-            minMerge = cell.MergeDown;
+            minMerge = rowIndex + cell.MergeDown - row;
             minCell = cell;
           }
         }
-        else if (cell.Row.Index > row)
+        else if (rowIndex > row)
           break;
       }
       return minCell;
@@ -644,11 +651,12 @@ namespace MigraDocCore.Rendering
       int lastConnectedRow = row;
       foreach (Cell cell in this.mergedCells)
       {
-        if (cell.Row.Index <= lastConnectedRow)
+        var index = cell.Row.Index; // Note: Caching index here for speedup for large tables.
+        if (index <= lastConnectedRow)
         {
           int downConnection = Math.Max(cell.Row.KeepWith, cell.MergeDown);
-          if (lastConnectedRow < cell.Row.Index + downConnection)
-            lastConnectedRow = cell.Row.Index + downConnection;
+          if (lastConnectedRow < index + downConnection)
+            lastConnectedRow = index + downConnection;
         }
       }
       return lastConnectedRow;

--- a/MigraDocCore.Rendering/MigraDoc.Rendering/TableRenderer.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/TableRenderer.cs
@@ -30,6 +30,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using PdfSharpCore.Drawing;
 using MigraDocCore.DocumentObjectModel;
 using MigraDocCore.DocumentObjectModel.Visitors;
@@ -278,7 +279,7 @@ namespace MigraDocCore.Rendering
 
     void FormatCells()
     {
-      this.formattedCells = new SortedList(new CellComparer());
+      this.formattedCells = new SortedList<Cell, FormattedCell>(new CellComparer());
       foreach (Cell cell in this.mergedCells)
       {
         FormattedCell formattedCell = new FormattedCell(cell, this.documentRenderer, this.mergedCells.GetEffectiveBorders(cell), this.fieldInfos, 0, 0);
@@ -491,7 +492,7 @@ namespace MigraDocCore.Rendering
 
     void CreateConnectedRows()
     {
-      this.connectedRowsMap = new SortedList();
+      this.connectedRowsMap = new SortedList<int, int>();
       foreach (Cell cell in this.mergedCells)
       {
         if (!this.connectedRowsMap.ContainsKey(cell.Row.Index))
@@ -504,7 +505,7 @@ namespace MigraDocCore.Rendering
 
     void CreateConnectedColumns()
     {
-      this.connectedColumnsMap = new SortedList();
+      this.connectedColumnsMap = new SortedList<int, int>();
       foreach (Cell cell in this.mergedCells)
       {
         if (!this.connectedColumnsMap.ContainsKey(cell.Column.Index))
@@ -517,7 +518,7 @@ namespace MigraDocCore.Rendering
 
     void CreateBottomBorderMap()
     {
-      this.bottomBorderMap = new SortedList();
+      this.bottomBorderMap = new SortedList<int, XUnit>();
       this.bottomBorderMap.Add(0, XUnit.FromPoint(0));
       while (!this.bottomBorderMap.ContainsKey(this.table.Rows.Count))
       {
@@ -562,8 +563,8 @@ namespace MigraDocCore.Rendering
     void CreateNextBottomBorderPosition()
     {
       int lastIdx = bottomBorderMap.Count - 1;
-      int lastBorderRow = (int)bottomBorderMap.GetKey(lastIdx);
-      XUnit lastPos = (XUnit)bottomBorderMap.GetByIndex(lastIdx);
+      int lastBorderRow = (int)bottomBorderMap.Keys[lastIdx];
+      XUnit lastPos = (XUnit)bottomBorderMap.Values[lastIdx];
       Cell minMergedCell = GetMinMergedCell(lastBorderRow);
       FormattedCell minMergedFormattedCell = (FormattedCell)this.formattedCells[minMergedCell];
       XUnit maxBottomBorderPosition = lastPos + minMergedFormattedCell.InnerHeight;
@@ -686,10 +687,10 @@ namespace MigraDocCore.Rendering
 
     Table table;
     MergedCellList mergedCells;
-    SortedList formattedCells;
-    SortedList bottomBorderMap;
-    SortedList connectedRowsMap;
-    SortedList connectedColumnsMap;
+    SortedList<Cell, FormattedCell> formattedCells;
+    SortedList<int, XUnit> bottomBorderMap;
+    SortedList<int, int> connectedRowsMap;
+    SortedList<int, int> connectedColumnsMap;
 
     int lastHeaderRow;
     int lastHeaderColumn;


### PR DESCRIPTION
Made some performance improvement to rendering large tables. Some of these are from the 1.50 version, but I also added some low-hanging fruit I discovered with profiling. None of the changes should have an effect on anything other than performance.

For 2000 rows, the execution time is 8.8% of the original code; for 5000 rows, the execution time is 4.7% (local tests on my system). The speed improvements seem to grow the bigger the table gets. Yes, this means 3.5s vs. 39.4s for 2000 rows and 11.2s vs. 235s for 5000 rows, which is why we desperately need this.

Updating to .NET 5 actually made a large speed-up as well; it seems that the relative improvement of my updated version was even boosted more by that, because with the previous version, it was "only" 11%/6.3%. The .NET update improves the original code's execution time by about one third, but my code by half, so I'm quite happy about that.

NOTE: I have created a manual unit test for speed tests; if you want I can add it to the pull request, but I didn't because to make things easy, I just added a single test to the PdfSharpCore.Test assembly, but it's actually a Migradoc test.