### PR TITLE
Allow XGraphics._render defining code into .net5.0

### DIFF
--- a/PdfSharpCore/Drawing/XGraphics.cs
+++ b/PdfSharpCore/Drawing/XGraphics.cs
@@ -516,6 +516,8 @@ namespace PdfSharpCore.Drawing  // #??? aufräumen
             _gsStack = new GraphicsStateStack(this);
 #if CORE
             TargetContext = XGraphicTargetContext.CORE;
+#endif
+#if CORE || NET5_0
             _drawGraphics = false;
             if (form.Owner != null)
                 _renderer = new XGraphicsPdfRenderer(form, this);


### PR DESCRIPTION
Hi all!

None of the `XGraphics.Draw<something>` methods work when used with an `XForm` as the `XGraphics._renderer` property is null.

The goal is to use an `XForm` to insert a cropped portion of a PDF page onto a page in a new document.

Thanks for the great project!

Nikola