### PR TITLE
Mod/expose current MigraDoc position

### DIFF
--- a/MigraDocCore.Rendering/MigraDoc.Rendering/FormattedDocument.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/FormattedDocument.cs
@@ -425,10 +425,10 @@ namespace MigraDocCore.Rendering
 
 
         /// <summary>
-        /// Returns the absolute Y postion of the last item on last page in points.
+        /// Returns the absolute Y position of the last item on the last page in points.
         /// Must be called after rendering the document.
         /// </summary>
-        /// <returns>double the Y Position.</returns>
+        /// <returns>The current Y position at the end of the last page.</returns>
         public double GetCurrentMigraDocPosition()
         {
             RenderInfo[] RenderInfos = GetRenderInfos(PageCount);

--- a/MigraDocCore.Rendering/MigraDoc.Rendering/FormattedDocument.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/FormattedDocument.cs
@@ -423,6 +423,19 @@ namespace MigraDocCore.Rendering
             return this.pageInfos[page];
         }
 
+
+        /// <summary>
+        /// Returns the absolute Y postion of the last item on last page in points.
+        /// Must be called after rendering the document.
+        /// </summary>
+        /// <returns>double the Y Position.</returns>
+        public double GetCurrentMigraDocPosition()
+        {
+            RenderInfo[] RenderInfos = GetRenderInfos(PageCount);
+            RenderInfo r = RenderInfos[RenderInfos.Length - 1];
+            return r.LayoutInfo.ContentArea.Y + r.LayoutInfo.ContentArea.Height;
+        }
+
         #region IAreaProvider Members
 
         Area IAreaProvider.GetNextArea()


### PR DESCRIPTION
Hello!

The idea behind this one comes from the need to create a pdf document by splicing together a bunch of different content using PdfSharp. Some of that content are tables, and MigraDoc tables are used.

The new method in this PR exposes the Y position of the bottom of the last element on the last page that MigraDoc generates. This position is planned to be used to determine the **available leftover space** for any element that is inserted into the main document after the current MigraDoc render.

...and in case anyone was wondering, due to the complexity of the splicing it is not possible to just use MigraDoc to generate the entire document.
