### PR TITLE
Combination chart issue fixed when more than 2 series added

### DIFF
--- a/PdfSharpCore.Charting/PdfSharp.Charting.Renderers/CombinationChartRenderer.cs
+++ b/PdfSharpCore.Charting/PdfSharp.Charting.Renderers/CombinationChartRenderer.cs
@@ -277,7 +277,7 @@ namespace PdfSharpCore.Charting.Renderers
       cri.commonSeriesRendererInfos = cri.seriesRendererInfos;
       if (areaSeries.Count > 0)
       {
-        cri.areaSeriesRendererInfos = new SeriesRendererInfo[columnSeries.Count];
+        cri.areaSeriesRendererInfos = new SeriesRendererInfo[areaSeries.Count];
         areaSeries.CopyTo(cri.areaSeriesRendererInfos);
       }
       if (columnSeries.Count > 0)
@@ -287,7 +287,7 @@ namespace PdfSharpCore.Charting.Renderers
       }
       if (lineSeries.Count > 0)
       {
-        cri.lineSeriesRendererInfos = new SeriesRendererInfo[columnSeries.Count];
+        cri.lineSeriesRendererInfos = new SeriesRendererInfo[lineSeries.Count];
         lineSeries.CopyTo(cri.lineSeriesRendererInfos);
       }
     }


### PR DESCRIPTION
Issue fix - Combination charts does not work when multiple chart types with more than 2 series added.