### PR TITLE
Fonts improves

### DIFF
--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -39,7 +39,7 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SixLabors.ImageSharp" Version="2.0" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta15" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta16" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -38,7 +38,7 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
     <Folder Include="Resources\images\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.0" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta15" />
   </ItemGroup>
 

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -39,7 +39,7 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta0013" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -38,7 +38,7 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
     <Folder Include="Resources\images\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta16" />
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 **PdfSharpCore** is a partial port of [PdfSharp.Xamarin](https://github.com/roceh/PdfSharp.Xamarin/) for .NET Standard
 Additionally MigraDoc has been ported as well (from version 1.32).
-Images have been implemented with [ImageSharp](https://github.com/JimBobSquarePants/ImageSharp/), which is still in Alpha. They State on their readme that it is still in Alpha status and shouldn't be used in productive environments. Since I didn't find any good alternatives it's still used.
-
-ImageSharp being Alpha isn't a big issue either since this code isn't by far done yet. So please chime in ;)
+Images have been implemented with [ImageSharp](https://github.com/SixLabors/ImageSharp), which has a stable status.
 
 **PdfSharp.Xamarin** is a partial port of [PdfSharp](http://www.pdfsharp.net/) for iOS and Android using Xamarin, it allows for creation and modification of PDF files.
 


### PR DESCRIPTION
* Small improvement of font loader
* update README about `ImageSharp`

The latest version `ImageSharp` 2.0 is not support `.NET Standard 1.3 target`: https://github.com/SixLabors/ImageSharp/pull/1888
[Microsoft recommend .NET Standard 2.0](https://docs.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-1-0), maybe drop 1.3?