### PR TITLE
Paragraph line break improvement

### DIFF
--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Visitors/PdfFlattenVisitor.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Visitors/PdfFlattenVisitor.cs
@@ -124,14 +124,14 @@ namespace MigraDocCore.DocumentObjectModel.Visitors
                 currentString = "";
                 break;
 
-              case '­': //soft hyphen
+              case Chars.SoftHyphen: //soft hyphen
                 if (currentString != "")
                 {
                   elements.InsertObject(idx + insertedObjects, new Text(currentString));
                   ++insertedObjects;
                   currentString = "";
                 }
-                elements.InsertObject(idx + insertedObjects, new Text("­"));
+                elements.InsertObject(idx + insertedObjects, new Text(new string(Chars.SoftHyphen, 1)));
                 ++insertedObjects;
                 currentString = "";
                 break;

--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Visitors/PdfFlattenVisitor.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Visitors/PdfFlattenVisitor.cs
@@ -118,6 +118,7 @@ namespace MigraDocCore.DocumentObjectModel.Visitors
                 ++insertedObjects;
                 break;
 
+              case Chars.ZeroWidthSpace:
               case '-': //minus
                 elements.InsertObject(idx + insertedObjects, new Text(currentString + ch));
                 ++insertedObjects;

--- a/MigraDocCore.DocumentObjectModel/MigraDoc/MigraDoc.DocumentObjectModel/Chars.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc/MigraDoc.DocumentObjectModel/Chars.cs
@@ -77,7 +77,7 @@ namespace MigraDocCore.DocumentObjectModel
     public const char NumberSign = '#';
     public const char Question = '?';
     public const char Hyphen = '-';  // char(45)
-    public const char SoftHyphen = '­';  // char(173)
+    public const char SoftHyphen = '\u00ad';  // char(173)
     public const char Currency = '¤';
   }
 }

--- a/MigraDocCore.DocumentObjectModel/MigraDoc/MigraDoc.DocumentObjectModel/Chars.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc/MigraDoc.DocumentObjectModel/Chars.cs
@@ -79,5 +79,6 @@ namespace MigraDocCore.DocumentObjectModel
     public const char Hyphen = '-';  // char(45)
     public const char SoftHyphen = '\u00ad';  // char(173)
     public const char Currency = '¤';
+    public const char ZeroWidthSpace = '\u200b';
   }
 }


### PR DESCRIPTION
I'm currently trying to improve line-breaking within narrow tables and was therefore working on the basic line-breaking code (in PdfFlattenVisitor).

There was a problem with soft-hyphens which I believe come from a problem with the encoding of the source file, so I replaced the constant used in Migradoc with a Unicode code-point (instead of a Latin-1-encoded SHY character), and I replaced the code that would break on a soft-hyphen to use that constant, rather than repeating the SHY character. This will now work independent of the actual encoding of the source files. Note that in the diff, it looks like I've replaced an empty string with the constant, but it is actually the SHY character that was replaced :)

The actual addition, however, is added support for zero-width spaces. This should allow us to fulfill most of our line-break needs from outside (by injecting zero-width spaces at appropriate positions). Since the whole purpose of this character is breaking at that point if required, I figured it would be good non-breaking (pun intended) change to PdfSharpCore.