### PR TITLE
Imagesharp is not in alpha, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 # PdfSharpCore
 
-**PdfSharpCore** is a partial port of [PdfSharp.Xamarin](https://github.com/roceh/PdfSharp.Xamarin/) for .NET Standard
+**PdfSharpCore** is a partial port of [PdfSharp](http://www.pdfsharp.net/) for .NET Standard. 
 Additionally MigraDoc has been ported as well (from version 1.32).
-Images have been implemented with [ImageSharp](https://github.com/JimBobSquarePants/ImageSharp/), which is still in Alpha. They State on their readme that it is still in Alpha status and shouldn't be used in productive environments. Since I didn't find any good alternatives it's still used.
 
-ImageSharp being Alpha isn't a big issue either since this code isn't by far done yet. So please chime in ;)
+Images have been implemented with [ImageSharp](https://github.com/JimBobSquarePants/ImageSharp/). 
 
-**PdfSharp.Xamarin** is a partial port of [PdfSharp](http://www.pdfsharp.net/) for iOS and Android using Xamarin, it allows for creation and modification of PDF files.
-
-
+**PdfSharp.Xamarin** is a partial port of [PdfSharp.Xamarin](https://github.com/roceh/PdfSharp.Xamarin/) for iOS and Android using Xamarin, it allows for creation and modification of PDF files.
 
 ###### Example project 
 


### PR DESCRIPTION
Imagesharp is not in alpha for quite some time (v2 is already released). 

Also updated links as core was pointing to xamarin & other way around.