### PR TITLE
Update build SDK images

### DIFF
--- a/.ci/tasks/build.yaml
+++ b/.ci/tasks/build.yaml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: mcr.microsoft.com/dotnet/sdk
-    tag: 5.0.103-alpine3.12-amd64
+    tag: 7.0-alpine3.15-amd64
 inputs:
 - name: source
 params:

--- a/.ci/tasks/publish-nugget.yaml
+++ b/.ci/tasks/publish-nugget.yaml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: mcr.microsoft.com/dotnet/sdk
-    tag: 5.0.103-alpine3.12-amd64
+    tag: 7.0-alpine3.15-amd64
 inputs:
 - name: source
 - name: version


### PR DESCRIPTION
We now support net6, older SDK can no longer build.
Upgrading to 7.0