### PR TITLE
expose PdfReadAccuracy through XPdfForm

### DIFF
--- a/PdfSharpCore/Drawing/XImage.cs
+++ b/PdfSharpCore/Drawing/XImage.cs
@@ -33,6 +33,7 @@ using System.IO;
 using PdfSharpCore.Pdf.IO;
 using PdfSharpCore.Pdf.Advanced;
 using MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes;
+using PdfSharpCore.Pdf.IO.enums;
 using static MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes.ImageSource;
 using PdfSharpCore.Utils;
 using SixLabors.ImageSharp.PixelFormats;
@@ -119,8 +120,20 @@ namespace PdfSharpCore.Drawing
         /// <param name="path">The path to a BMP, PNG, GIF, JPEG, TIFF, or PDF file.</param>
         public static XImage FromFile(string path)
         {
+            return FromFile(path, PdfReadAccuracy.Strict);
+        }
+
+        /// <summary>
+        /// Creates an image from the specified file.
+        /// For non-pdf files, this requires that an instance of an implementation of <see cref="T:MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes.ImageSource"/> be set on the `ImageSource.ImageSourceImpl` property.
+        /// For .NetCore apps, if this property is null at this point, then <see cref="T:PdfSharpCore.Utils.ImageSharpImageSource"/> with <see cref="T:SixLabors.ImageSharp.PixelFormats.Rgba32"/> Pixel Type is used
+        /// </summary>
+        /// <param name="path">The path to a BMP, PNG, GIF, JPEG, TIFF, or PDF file.</param>
+        /// <param name="accuracy">Moderate allows for broken references when using a PDF file.</param>
+        public static XImage FromFile(string path, PdfReadAccuracy accuracy)
+        {
             if (PdfReader.TestPdfFile(path) > 0)
-                return new XPdfForm(path);
+                return new XPdfForm(path, accuracy);
             return new XImage(path);
         }
 

--- a/PdfSharpCore/Pdf.Internal/ThreadLocalStorage.cs
+++ b/PdfSharpCore/Pdf.Internal/ThreadLocalStorage.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using PdfSharpCore.Pdf.IO;
+using PdfSharpCore.Pdf.IO.enums;
 
 namespace PdfSharpCore.Pdf.Internal
 {
@@ -55,7 +56,7 @@ namespace PdfSharpCore.Pdf.Internal
             _importedDocuments.Remove(path);
         }
 
-        public PdfDocument GetDocument(string path)
+        public PdfDocument GetDocument(string path, PdfReadAccuracy accuracy)
         {
             Debug.Assert(path.StartsWith("*") || Path.IsPathRooted(path), "Path must be full qualified.");
 
@@ -69,7 +70,7 @@ namespace PdfSharpCore.Pdf.Internal
             }
             if (document == null)
             {
-                document = PdfReader.Open(path, PdfDocumentOpenMode.Import);
+                document = PdfReader.Open(path, PdfDocumentOpenMode.Import, accuracy);
                 _importedDocuments.Add(path, document.Handle);
             }
             return document;


### PR DESCRIPTION
Aside from `PdfReader`, it's useful to also expose `PdfReadAccuracy `  through `XPdfForm` (where currently it still defaults to `Strict` and gives the user code no option).