### PR TITLE
Make FontResolver.GetFont() method available to be overriden

### DIFF
--- a/PdfSharpCore/Utils/FontResolver.cs
+++ b/PdfSharpCore/Utils/FontResolver.cs
@@ -153,7 +153,7 @@ namespace PdfSharpCore.Utils
             return font;
         }
 
-        public byte[] GetFont(string faceFileName)
+        public virtual byte[] GetFont(string faceFileName)
         {
             using (System.IO.MemoryStream ms = new System.IO.MemoryStream())
             {


### PR DESCRIPTION
I have a situation when all installed system fonts needs to be supported along with 1 custom icon font located in the program resources. At the moment, I have to copy-paste the entire FontResolver.cs file, because GetFont() method can't be overriden (as ResolveTypeface does)