### PR TITLE
Add option to create ImageSource directly from ImageSharp image

### DIFF
--- a/PdfSharpCore.Test/PdfSharpCore.Test.csproj
+++ b/PdfSharpCore.Test/PdfSharpCore.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/PdfSharpCore/Utils/ImageSharpImageSource.cs
+++ b/PdfSharpCore/Utils/ImageSharpImageSource.cs
@@ -12,6 +12,13 @@ namespace PdfSharpCore.Utils
 {
     public class ImageSharpImageSource<TPixel> : ImageSource where TPixel : unmanaged, IPixel<TPixel>
     {
+
+        public static IImageSource FromImageSharpImage(Image<TPixel> image, IImageFormat imgFormat, int? quality = 75)
+        {
+            var _path = "*" + Guid.NewGuid().ToString("B");
+            return new ImageSharpImageSourceImpl<TPixel>(_path, image, (int)quality, imgFormat is PngFormat);
+        }
+
         protected override IImageSource FromBinaryImpl(string name, Func<byte[]> imageSource, int? quality = 75)
         {
             var image = Image.Load<TPixel>(imageSource.Invoke(), out IImageFormat imgFormat);


### PR DESCRIPTION
If you already have a loaded ImageSharp image (maybe to apply some effects) this image currently cannot be supplied to PdfSharp Core. Instead the image needs to be encoded to a byte array and this can then be used to create an ImageSource (decoding it to a ImageSharp image again).

This pull-request enables the user to supply a ImageSharp image directly, without encoding and decoding it. This should be an obvious performance win. (I did not create any formal benchmarks)

It is not super straight forward how to use this, because I wanted to change as little code as possible, but I added a test that shows how to use this feature. I didn't add a convenience method to ImageSource or XImage to keep those independent of ImageSharp.

I hope people will find this useful and look forward to your feedback.

(This PR also runs the tests under .Net 6.0 as .Net 5.0 is EOL now.)