### PR TITLE
fix (Fonts): Type1 font handling (bump SixLabors.Fonts)

### DIFF
--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -39,7 +39,7 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta0013" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta17" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updating the SixLabors.Fonts 1.0.0.-beta17 which includes a fix that lets Type1 fonts be handled.
Resolves #175 

Fix was in https://github.com/SixLabors/Fonts/releases/tag/v1.0.0-beta16 