### PR TITLE
Improved stream-decoding

### DIFF
--- a/PdfSharpCore/Pdf.Advanced/PdfContent.cs
+++ b/PdfSharpCore/Pdf.Advanced/PdfContent.cs
@@ -78,13 +78,13 @@ namespace PdfSharpCore.Pdf.Advanced
             {
                 if (value)
                 {
-                    PdfItem filter = Elements["/Filter"];
+                    PdfItem filter = Elements[PdfStream.Keys.Filter];
                     if (filter == null)
                     {
                         byte[] bytes = Filtering.FlateDecode.Encode(Stream.Value, _document.Options.FlateEncodeMode);
                         Stream.Value = bytes;
-                        Elements.SetInteger("/Length", Stream.Length);
-                        Elements.SetName("/Filter", "/FlateDecode");
+                        Elements.SetInteger(PdfStream.Keys.Length, Stream.Length);
+                        Elements.SetName(PdfStream.Keys.Filter, "/FlateDecode");
                     }
                 }
             }
@@ -97,15 +97,17 @@ namespace PdfSharpCore.Pdf.Advanced
         {
             if (Stream != null && Stream.Value != null)
             {
-                PdfItem item = Elements["/Filter"];
+                PdfItem item = Elements[PdfStream.Keys.Filter];
                 if (item != null)
                 {
-                    byte[] bytes = Filtering.Decode(Stream.Value, item);
+                    var decodeParms = Elements[PdfStream.Keys.DecodeParms];
+                    byte[] bytes = Filtering.Decode(Stream.Value, item, decodeParms);
                     if (bytes != null)
                     {
                         Stream.Value = bytes;
-                        Elements.Remove("/Filter");
-                        Elements.SetInteger("/Length", Stream.Length);
+                        Elements.Remove(PdfStream.Keys.Filter);
+                        Elements.Remove(PdfStream.Keys.DecodeParms);
+                        Elements.SetInteger(PdfStream.Keys.Length, Stream.Length);
                     }
                 }
             }

--- a/PdfSharpCore/Pdf.Advanced/PdfCrossReferenceStream.cs
+++ b/PdfSharpCore/Pdf.Advanced/PdfCrossReferenceStream.cs
@@ -47,9 +47,10 @@ namespace PdfSharpCore.Pdf.Advanced
 
         public readonly List<CrossReferenceStreamEntry> Entries = new List<CrossReferenceStreamEntry>();
 
+        [DebuggerDisplay("{Type} {Field2} {Field3}")]
         public struct CrossReferenceStreamEntry
         {
-            // Reference: TABLE 3.16  Entries in a cross-refernece stream / Page 109
+            // Reference: TABLE 3.16  Entries in a cross-reference stream / Page 109
 
             public uint Type;  // 0, 1, or 2.
 

--- a/PdfSharpCore/Pdf.Filters/Filter.cs
+++ b/PdfSharpCore/Pdf.Filters/Filter.cs
@@ -37,7 +37,15 @@ namespace PdfSharpCore.Pdf.Filters
     /// </summary>
     public class FilterParms
     {
-        // not yet used
+        /// <summary>
+        /// Gets the decoding-parameters for a filter. May be null
+        /// </summary>
+        public PdfDictionary DecodeParms { get; private set; }
+
+        public FilterParms(PdfDictionary decodeParms)
+        {
+            DecodeParms = decodeParms;
+        }
     }
 
     /// <summary>
@@ -68,9 +76,9 @@ namespace PdfSharpCore.Pdf.Filters
         /// <summary>
         /// Decodes the specified data.
         /// </summary>
-        public byte[] Decode(byte[] data)
+        public byte[] Decode(byte[] data, PdfDictionary decodeParms)
         {
-            return Decode(data, null);
+            return Decode(data, new FilterParms(decodeParms));
         }
 
         /// <summary>

--- a/PdfSharpCore/Pdf.Filters/FlateDecode.cs
+++ b/PdfSharpCore/Pdf.Filters/FlateDecode.cs
@@ -98,6 +98,8 @@ namespace PdfSharpCore.Pdf.Filters
             msOutput.Flush();
             if (msOutput.Length >= 0)
             {
+                if (parms.DecodeParms != null)
+                    return StreamDecoder.Decode(msOutput.ToArray(), parms.DecodeParms);
                 return msOutput.ToArray();
             }
             return null;

--- a/PdfSharpCore/Pdf.Filters/LzwDecode.cs
+++ b/PdfSharpCore/Pdf.Filters/LzwDecode.cs
@@ -101,6 +101,8 @@ namespace PdfSharpCore.Pdf.Filters
 
             if (outputStream.Length >= 0)
             {
+                if (parms.DecodeParms != null)
+                    return StreamDecoder.Decode(outputStream.ToArray(), parms.DecodeParms);
                 return outputStream.ToArray();
             }
             return null;

--- a/PdfSharpCore/Pdf.Filters/PngFilter.cs
+++ b/PdfSharpCore/Pdf.Filters/PngFilter.cs
@@ -1,0 +1,83 @@
+﻿using PdfSharpCore.Pdf.IO;
+using System;
+
+namespace PdfSharpCore.Pdf.Filters
+{
+    internal static class PngFilter
+    {
+        /// <summary>
+        /// Implements PNG-Filtering according to the PNG-specification<br></br>
+        /// see: https://datatracker.ietf.org/doc/html/rfc2083#section-6
+        /// </summary>
+        /// <param name="stride">The width of a scanline in bytes</param>
+        /// <param name="bpp">Bytes per pixel</param>
+        /// <param name="inData">The input data</param>
+        /// <param name="inData">The target array where the unfiltered data is stored</param>
+        /// <returns></returns>
+        internal static void Unfilter(int stride, int bpp, byte[] inData, byte[] outData)
+        {
+            var prevRow = new byte[stride];
+            var row = new byte[stride];
+            var pos = 0;
+            var outIndex = 0;
+            while (pos < inData.Length)
+            {
+                Array.Copy(inData, pos + 1, row, 0, stride);
+                var filterType = inData[pos];
+                if (filterType > 4)
+                    throw new PdfReaderException(string.Format("Unexpected Png-Predictor {0} in Xref Stream. Expected 0 to 4.", filterType));
+                switch (filterType)
+                {
+                    case 0:         // None
+                        for (var i = 0; i < row.Length; i++)
+                            outData[outIndex++] = row[i];
+                        break;
+                    case 1:         // Sub
+                        for (var i = 0; i < row.Length; i++)
+                        {
+                            var left = i < bpp ? 0 : outData[outIndex - bpp];
+                            outData[outIndex++] = (byte)(row[i] + left);
+                        }
+                        break;
+                    case 2:         // Up
+                        for (var i = 0; i < row.Length; i++)
+                            outData[outIndex++] = (byte)(row[i] + prevRow[i]);
+                        break;
+                    case 3:         // Average
+                        for (var i = 0; i < row.Length; i++)
+                        {
+                            var left = i < bpp ? 0 : outData[outIndex - bpp];
+                            outData[outIndex++] = (byte)(row[i] + (byte)((left + prevRow[i]) / 2));
+                        }
+                        break;
+                    case 4:         // Paeth
+                        for (var i = 0; i < row.Length; i++)
+                        {
+                            var left = i < bpp ? (byte)0 : outData[outIndex - bpp];
+                            var above = prevRow[i];
+                            var aboveLeft = i < bpp ? (byte)0 : prevRow[i - bpp];
+                            outData[outIndex++] = (byte)(row[i] + PaethPredictor(left, above, aboveLeft));
+                        }
+                        break;
+                }
+                // remember current scanline
+                Array.Copy(outData, outIndex - stride, prevRow, 0, stride);
+                pos += stride + 1;    // each scanline is preceded by a predictor-byte
+            }
+        }
+
+        // https://datatracker.ietf.org/doc/html/rfc2083#page-36
+        private static byte PaethPredictor(byte a, byte b, byte c)
+        {
+            var p = a + b - c;
+            var pa = Math.Abs(p - a);
+            var pb = Math.Abs(p - b);
+            var pc = Math.Abs(p - c);
+            if (pa <= pb && pa <= pc)
+                return a;
+            else if (pb <= pc)
+                return b;
+            return c;
+        }
+    }
+}

--- a/PdfSharpCore/Pdf.Filters/StreamDecoder.cs
+++ b/PdfSharpCore/Pdf.Filters/StreamDecoder.cs
@@ -1,0 +1,60 @@
+﻿using PdfSharpCore.Pdf.IO;
+using System;
+
+namespace PdfSharpCore.Pdf.Filters
+{
+    internal static class StreamDecoder
+    {
+        // PdfReference, chapter 7.4.4.3
+
+        /// <summary>
+        /// Further decodes a stream of bytes that were processed by the Flate- or LZW-decoder. 
+        /// </summary>
+        /// <param name="data">The data to decode</param>
+        /// <param name="decodeParms">Parameters for the decoder. If this is null, <paramref name="data"/> is returned unchanged</param>
+        /// <returns>The decoded data as a byte-array</returns>
+        /// <exception cref="PdfReaderException"></exception>
+        /// <exception cref="NotImplementedException"></exception>
+        public static byte[] Decode(byte[] data, PdfDictionary decodeParms)
+        {
+            if (decodeParms == null)
+                return data;
+
+            var predictor = decodeParms.Elements.GetInteger("/Predictor");
+            var colors = decodeParms.Elements.GetInteger("/Colors");
+            var bpc = decodeParms.Elements.GetInteger("/BitsPerComponent");
+            var columns = decodeParms.Elements.GetInteger("/Columns");
+
+            // set up defaults according to the spec
+            if (predictor < 1)
+                predictor = 1;
+            if (colors < 1)
+                colors = 1;
+            if (bpc < 1)
+                bpc = 8;
+            if (columns < 1)
+                columns = 1;
+
+            if (predictor == 1)     // no prediction, return data as is
+                return data;
+
+            // TIFF predictor. TODO: implement
+            if (predictor == 2)
+                throw new NotImplementedException("TIFF predictor is not implemented");
+
+            // PNG predictors
+            if (predictor >= 10 && predictor <= 15)
+            {
+                if (bpc != 1 && bpc != 2 && bpc != 4 && bpc != 8 && bpc != 16)
+                    throw new PdfReaderException("Invalid number of bits per component");
+                var stride = (bpc * colors * columns + 7) / 8;
+                var rows = data.Length / (stride + 1);
+                var unfilteredData = new byte[rows * stride];
+                PngFilter.Unfilter(stride, (bpc * colors + 7) / 8, data, unfilteredData);
+                return unfilteredData;
+            }
+
+            throw new PdfReaderException("Invalid predictor " + predictor);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for all 5 PNG-Predictors that may be used in flate- or lzw-encoded streams.
It also obsoletes a "HACK" when processing CrossReferenceStreams. (because all decoding is now done by the stream itself)

Resolves #222 