### PR TITLE
chore (Build): Ignore NU5104 warning about beta packages 

### DIFF
--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -20,6 +20,11 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
     <DefineConstants>TRACE;DEBUG;</DefineConstants>
   </PropertyGroup>
 
+	<PropertyGroup>
+        <!--skip warning due to skiplabours.fonts being beta -->
+		<NoWarn>NU5104</NoWarn>
+	</PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;RELEASE;</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
Due to `SixLabours.Fonts` being beta, (has been for some time). Ignore [NU5104](https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5104) warning