### PR TITLE
fix (PdfDate): Specify DateTimeKind UTC type when parsing.

### DIFF
--- a/PdfSharpCore.Test/Pdfs/PdfDateTests.cs
+++ b/PdfSharpCore.Test/Pdfs/PdfDateTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using FluentAssertions;
+using PdfSharpCore.Pdf;
+using Xunit;
+
+namespace PdfSharpCore.Test.Pdfs
+{
+    public class PdfDateTests
+    {
+        // format for pdf date is generally D:YYYYMMDDHHmmSSOHH'mm'
+
+        [Fact]
+        public void ParseDateString_WithTimezoneOffset()
+        {
+            var pdfDate = new PdfDate("D:19981223195200-02'00'");
+            var expectedDateWithOffset = new DateTimeOffset(new DateTime(1998, 12, 23, 19, 52, 0), new TimeSpan(-2, 0, 0));
+            pdfDate.Value.ToUniversalTime().Should().Be(expectedDateWithOffset.UtcDateTime);
+        }
+
+        [Fact]
+        public void ParseDateString_WithNoOffset()
+        {
+            var pdfDate = new PdfDate("D:19981223195200Z");
+            var expectedDateWithOffset = new DateTimeOffset(new DateTime(1998, 12, 23, 19, 52, 0), new TimeSpan(0, 0, 0));
+            pdfDate.Value.ToUniversalTime().Should().Be(expectedDateWithOffset.UtcDateTime);
+        }
+    }
+}

--- a/PdfSharpCore/Pdf.IO/Parser.cs
+++ b/PdfSharpCore/Pdf.IO/Parser.cs
@@ -1372,6 +1372,16 @@ namespace PdfSharpCore.Pdf.IO
         /// <summary>
         /// Parses a PDF date string.
         /// </summary>
+        /// <remarks>
+        ///  Format is
+        /// YYYY Year MM month DD day (01-31)  HH hour (00-23)  mm minute (00-59) ss second (00.59)
+        /// O is the relationship of local time to Universal Time (UT), denoted by one of the characters +, -, or Z (see below)
+        /// HH followed by ' is the absolute value of the offset from UT in hours (00-23)
+        /// mm followed by ' is the absolute value of the offset from UT in minutes (00-59)
+        /// For example, December 23, 1998, at 7:52 PM, U.S.Pacific Standard Time, is represented by the string,
+        /// D:19981223195200-08'00'
+        /// </remarks>
+
         internal static DateTime ParseDateTime(string date, DateTime errorValue)  // TODO: TryParseDateTime
         {
             DateTime datetime = errorValue;
@@ -1379,7 +1389,6 @@ namespace PdfSharpCore.Pdf.IO
             {
                 if (date.StartsWith("D:"))
                 {
-                    // Format is
                     // D:YYYYMMDDHHmmSSOHH'mm'
                     //   ^2      ^10   ^16 ^20
                     int length = date.Length;
@@ -1387,20 +1396,20 @@ namespace PdfSharpCore.Pdf.IO
                     char o = 'Z';
                     if (length >= 10)
                     {
-                        year = Int32.Parse(date.Substring(2, 4));
-                        month = Int32.Parse(date.Substring(6, 2));
-                        day = Int32.Parse(date.Substring(8, 2));
+                        year = int.Parse(date.Substring(2, 4));
+                        month = int.Parse(date.Substring(6, 2));
+                        day = int.Parse(date.Substring(8, 2));
                         if (length >= 16)
                         {
-                            hour = Int32.Parse(date.Substring(10, 2));
-                            minute = Int32.Parse(date.Substring(12, 2));
-                            second = Int32.Parse(date.Substring(14, 2));
+                            hour = int.Parse(date.Substring(10, 2));
+                            minute = int.Parse(date.Substring(12, 2));
+                            second = int.Parse(date.Substring(14, 2));
                             if (length >= 23)
                             {
                                 if ((o = date[16]) != 'Z')
                                 {
-                                    hh = Int32.Parse(date.Substring(17, 2));
-                                    mm = Int32.Parse(date.Substring(20, 2));
+                                    hh = int.Parse(date.Substring(17, 2));
+                                    mm = int.Parse(date.Substring(20, 2));
                                 }
                             }
                         }
@@ -1417,7 +1426,7 @@ namespace PdfSharpCore.Pdf.IO
                             datetime = datetime.Subtract(ts);
                     }
                     // Now that we converted datetime to UTC, mark it as UTC.
-                    DateTime.SpecifyKind(datetime, DateTimeKind.Utc);
+                    datetime = DateTime.SpecifyKind(datetime, DateTimeKind.Utc);
                 }
                 else
                 {

--- a/PdfSharpCore/Pdf/PdfDate.cs
+++ b/PdfSharpCore/Pdf/PdfDate.cs
@@ -42,12 +42,6 @@ namespace PdfSharpCore.Pdf
         /// <summary>
         /// Initializes a new instance of the <see cref="PdfDate"/> class.
         /// </summary>
-        public PdfDate()
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PdfDate"/> class.
-        /// </summary>
         public PdfDate(string value)
         {
             _value = Parser.ParseDateTime(value, DateTime.MinValue);
@@ -64,20 +58,19 @@ namespace PdfSharpCore.Pdf
         /// <summary>
         /// Gets the value as DateTime.
         /// </summary>
-        public DateTime Value
-        {
+        public DateTime Value =>
             // This class must behave like a value type. Therefore it cannot be changed (like System.String).
-            get { return _value; }
-        }
-        DateTime _value;
+            _value;
+
+        readonly DateTime _value;
 
         /// <summary>
         /// Returns the value in the PDF date format.
         /// </summary>
         public override string ToString()
         {
-            string delta = _value.ToString("zzz").Replace(':', '\'');
-            return String.Format("D:{0:yyyyMMddHHmmss}{1}'", _value, delta);
+            var delta = _value.ToString("zzz").Replace(':', '\'');
+            return $"D:{_value:yyyyMMddHHmmss}{delta}'";
         }
 
         /// <summary>


### PR DESCRIPTION
Fix (PdfDate): should set DateTimeKind since date is converted to UTC.
credit to @AVTit at https://github.com/empira/PDFsharp/pull/126/files for original fix