### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,47 @@
 # PdfSharpCore
 
+[![NuGet Version](https://img.shields.io/nuget/v/PdfSharpCore.svg)](https://www.nuget.org/packages/PdfSharpCore/)
+[![CI](https://github.com/ststeiger/PdfSharpCore/actions/workflows/build.yml/badge.svg)](https://github.com/ststeiger/PdfSharpCore/actions/workflows/build.yml)
 [![codecov.io](https://codecov.io/github/ststeiger/PdfSharpCore/coverage.svg?branch=master)](https://codecov.io/github/ststeiger/PdfSharpCore?branch=master)
 
-**PdfSharpCore** is a partial port of [PdfSharp.Xamarin](https://github.com/roceh/PdfSharp.Xamarin/) for .NET Standard
+**PdfSharpCore** is a partial port of [PdfSharp.Xamarin](https://github.com/roceh/PdfSharp.Xamarin/) for .NET Standard.
 Additionally MigraDoc has been ported as well (from version 1.32).
-Images have been implemented with [ImageSharp](https://github.com/JimBobSquarePants/ImageSharp/), which is still in Alpha. They State on their readme that it is still in Alpha status and shouldn't be used in productive environments. Since I didn't find any good alternatives it's still used.
+Image support has been implemented with [SixLabors.ImageSharp](https://github.com/JimBobSquarePants/ImageSharp/) and Fonts support with [SixLabors.Fonts](https://github.com/SixLabors/Fonts).
 
-ImageSharp being Alpha isn't a big issue either since this code isn't by far done yet. So please chime in ;)
 
-###### Example project 
+## Table of Contents
 
-There was an example project here. <br />
-I've removed it from this project, and put it into a separate solution.
-You can find it [here](https://github.com/ststeiger/Stammbaum).<br />
-There's a default font-resolver in [FontResolver.cs](https://github.com/ststeiger/PdfSharpCore/blob/master/PdfSharpCore/Utils/FontResolver.cs).<br />
-It should work on Windows, Linux, OSX and Azure. <br />
-Some limitations apply. <br />
-See open issues.
+- [Documentation](docs/index.md)
+- [Example](#example)
+- [Contributing](#contributing)
+- [License](#license)
 
-## Example usage
+
+## Example
 
 ```cs
-//See the "Example" Project for a MigraDoc example
 static void Main(string[] args)
 {
-    GlobalFontSettings.FontResolver = new FontResolver();
-    
     var document = new PdfDocument();
     var page = document.AddPage();
     var gfx = XGraphics.FromPdfPage(page);
     var font = new XFont("OpenSans", 20, XFontStyle.Bold);
             
-    gfx.DrawString("Hello World!", font, XBrushes.Black, new XRect(20, 20, page.Width, page.Height), XStringFormats.Center);
+    gfx.DrawString(
+        "Hello World!", font, XBrushes.Black,
+        new XRect(20, 20, page.Width, page.Height),
+        XStringFormats.Center);
 
     document.Save("test.pdf");
 }
-
-// This implementation is obviously not very good --> Though it should be enough for everyone to implement their own.
-public class FontResolver : IFontResolver
-{
-    public byte[] GetFont(string faceName)
-    {
-        using(var ms = new MemoryStream())
-        {
-            using(var fs = File.Open(faceName, FileMode.Open))
-            {
-                fs.CopyTo(ms);
-                ms.Position = 0;
-                return ms.ToArray();
-                }
-            }
-        }
-        public FontResolverInfo ResolveTypeface(string familyName, bool isBold, bool isItalic)
-        {
-            if (familyName.Equals("OpenSans", StringComparison.CurrentCultureIgnoreCase))
-            {
-                if (isBold && isItalic)
-                {
-                    return new FontResolverInfo("OpenSans-BoldItalic.ttf");
-                }
-                else if (isBold)
-                {
-                    return new FontResolverInfo("OpenSans-Bold.ttf");
-                }
-                else if (isItalic)
-                {
-                    return new FontResolverInfo("OpenSans-Italic.ttf");
-                }
-                else
-                {
-                    return new FontResolverInfo("OpenSans-Regular.ttf");
-                }
-            }
-            return null;
-        }
-    }
-}
 ```
+
+
+## Contributing
+
+We appreciate feedback and contribution to this repo!
+
 
 ## License
 
-Copyright (c) 2005-2007 empira Software GmbH, Cologne (Germany)  
-Modified work Copyright (c) 2016 David Dunscombe
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+This software is released under the MIT License. See the [LICENSE](LICENCE.md) file for more info.


### PR DESCRIPTION
- simplify example, how to implement font resolver can be found in the documentation and by default there is already one
- align readme to other libraries: add pipeline batch and nuget package batch
- link documentation
- update info about ImageSharp and Fonts from SixLabs

Looks like this:
![image](https://user-images.githubusercontent.com/10164638/172580746-ff4708a2-ffe3-4324-ac22-5fa5cf81b6ac.png)
