### PR TITLE
Support for Windows fonts inside %LOCALAPPDATA%

### DIFF
--- a/PdfSharpCore/Utils/FontResolver.cs
+++ b/PdfSharpCore/Utils/FontResolver.cs
@@ -53,7 +53,19 @@ namespace PdfSharpCore.Utils
             if (isWindows)
             {
                 fontDir = System.Environment.ExpandEnvironmentVariables(@"%SystemRoot%\Fonts");
-                SSupportedFonts = System.IO.Directory.GetFiles(fontDir, "*.ttf", System.IO.SearchOption.AllDirectories);
+                var fontPaths = new List<string>();
+
+                var systemFontPaths = System.IO.Directory.GetFiles(fontDir, "*.ttf", System.IO.SearchOption.AllDirectories);
+                fontPaths.AddRange(systemFontPaths);
+
+                var appdataFontDir = System.Environment.ExpandEnvironmentVariables(@"%LOCALAPPDATA%\Microsoft\Windows\Fonts");
+                if(System.IO.Directory.Exists(appdataFontDir))
+                {
+                    var appdataFontPaths = System.IO.Directory.GetFiles(appdataFontDir, "*.ttf", System.IO.SearchOption.AllDirectories);
+                    fontPaths.AddRange(appdataFontPaths);
+                }
+
+                SSupportedFonts = fontPaths.ToArray();
                 SetupFontsFiles(SSupportedFonts);
                 return;
             }


### PR DESCRIPTION
Windows does not install fonts in C:\Windows\Fonts as default location anymore.
Instead, the fonts get copied to %LOCALAPPDATA%\Microsoft\Windows\Fonts.

This PR also checks this folder (if it exists) to include the fonts in the default `FontResolver`.