### PR TITLE
Return null if obj is of type PdfNull

### DIFF
--- a/PdfSharpCore/Pdf/PdfDictionary.cs
+++ b/PdfSharpCore/Pdf/PdfDictionary.cs
@@ -395,6 +395,10 @@ namespace PdfSharpCore.Pdf
                         this[key] = new PdfInteger();
                     return 0;
                 }
+
+                if (obj is PdfNull)
+                    return 0;
+
                 PdfReference reference = obj as PdfReference;
                 if (reference != null)
                     obj = reference.Value;


### PR DESCRIPTION
There is a check "obj == null", but not for PdfNull which is passed in into the dictionary if the value is null.

fixes #287 