### PR TITLE
Use unicode for encoding document metadata

### DIFF
--- a/PdfSharpCore.Test/CreateSimplePDF.cs
+++ b/PdfSharpCore.Test/CreateSimplePDF.cs
@@ -38,6 +38,28 @@ namespace PdfSharpCore.Test
         }
 
         [Fact]
+        public void CreateTestPdfWithUnicodeMetadata()
+        {
+            const string data = "English, Ελληνικά, 漢語";
+
+            var document = new PdfDocument();
+            document.Info.Title = data;
+            document.Info.Subject = data;
+            document.Info.Author = data;
+
+            using var ms = new MemoryStream();
+            document.AddPage();
+            document.Save(ms);
+            ms.Position = 0;
+
+            PdfDocument generatedDocument = Pdf.IO.PdfReader.Open(ms);
+
+            Assert.Equal(data, generatedDocument.Info.Title);
+            Assert.Equal(data, generatedDocument.Info.Subject);
+            Assert.Equal(data, generatedDocument.Info.Author);
+        }
+
+        [Fact]
         public void CreateTestPdfWithImage()
         {
             using var stream = new MemoryStream();

--- a/PdfSharpCore/Pdf/PdfDictionary.cs
+++ b/PdfSharpCore/Pdf/PdfDictionary.cs
@@ -587,6 +587,14 @@ namespace PdfSharpCore.Pdf
             }
 
             /// <summary>
+            /// Sets the entry to a string value with the specified encoding.
+            /// </summary>
+            public void SetString(string key, string value, PdfStringEncoding encoding)
+            {
+                this[key] = new PdfString(value, encoding);
+            }
+
+            /// <summary>
             /// Converts the specified value to a name.
             /// If the value does not exist, the function returns the empty string.
             /// </summary>

--- a/PdfSharpCore/Pdf/PdfDocumentInformation.cs
+++ b/PdfSharpCore/Pdf/PdfDocumentInformation.cs
@@ -53,7 +53,7 @@ namespace PdfSharpCore.Pdf
         public string Title
         {
             get { return Elements.GetString(Keys.Title); }
-            set { Elements.SetString(Keys.Title, value); }
+            set { Elements.SetString(Keys.Title, value, PdfStringEncoding.Unicode); }
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace PdfSharpCore.Pdf
         public string Author
         {
             get { return Elements.GetString(Keys.Author); }
-            set { Elements.SetString(Keys.Author, value); }
+            set { Elements.SetString(Keys.Author, value, PdfStringEncoding.Unicode); }
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace PdfSharpCore.Pdf
         public string Subject
         {
             get { return Elements.GetString(Keys.Subject); }
-            set { Elements.SetString(Keys.Subject, value); }
+            set { Elements.SetString(Keys.Subject, value, PdfStringEncoding.Unicode); }
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace PdfSharpCore.Pdf
         public string Keywords
         {
             get { return Elements.GetString(Keys.Keywords); }
-            set { Elements.SetString(Keys.Keywords, value); }
+            set { Elements.SetString(Keys.Keywords, value, PdfStringEncoding.Unicode); }
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace PdfSharpCore.Pdf
         public string Creator
         {
             get { return Elements.GetString(Keys.Creator); }
-            set { Elements.SetString(Keys.Creator, value); }
+            set { Elements.SetString(Keys.Creator, value, PdfStringEncoding.Unicode); }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #286.

I think document info should always be in unicode, regardless of the PDF body encoding.