### PR TITLE
drop .NET 5 condition in XGraphics.cs

### DIFF
--- a/PdfSharpCore/Drawing/XGraphics.cs
+++ b/PdfSharpCore/Drawing/XGraphics.cs
@@ -207,13 +207,11 @@ namespace PdfSharpCore.Drawing  // #??? aufräumen
             form.AssociateGraphics(this);
 
             _gsStack = new GraphicsStateStack(this);
-#if NET5_0
             _drawGraphics = false;
             if (form.Owner != null)
                 _renderer = new XGraphicsPdfRenderer(form, this);
             _pageSize = form.Size;
             Initialize();
-#endif
         }
 
         /// <summary>


### PR DESCRIPTION
-> in 51dd927 (2022-05-01) stale conditionals have been removed, .NET 5 condition was left and made XForm non-functional in .NET versions != 5.0