### PR TITLE
Ignore single backslash when scanning literal string

### DIFF
--- a/PdfSharpCore/Pdf.IO/Lexer.cs
+++ b/PdfSharpCore/Pdf.IO/Lexer.cs
@@ -500,7 +500,8 @@ namespace PdfSharpCore.Pdf.IO
                                     {
                                         // Octal character code.
                                         if (ch >= '8')
-                                            ParserDiagnostics.HandleUnexpectedCharacter(ch);
+                                            break; // Since the first possible octal character is not valid,
+                                                   // the backslash is ignored. 
 
                                         int n = ch - '0';
                                         if (char.IsDigit(_nextChar))  // Second octal character.
@@ -520,12 +521,6 @@ namespace PdfSharpCore.Pdf.IO
                                             }
                                         }
                                         ch = (char)n;
-                                    }
-                                    else
-                                    {
-                                        //TODO
-                                        // Debug.As sert(false, "Not implemented; unknown escape character.");
-                                        ParserDiagnostics.HandleUnexpectedCharacter(ch);
                                     }
                                     break;
                             }


### PR DESCRIPTION
This is a fix for #292 and possibly #84 (needs testing).
Both issues are related to un-escaped character sequences in literal scanning.

As stated in pdf specification:
> Within a literal string, the backslash () is used as an escape character for various purposes, such as to include newline characters, nonprinting ASCII characters, unbalanced parentheses, or the backslash character itself in the string. The char-acter immediately following the backslash determines its precise interpretation (see Table 3.2). If the character following the backslash is not one of those shown in the table, the backslash is ignored.

When opening a pdf with PdfSharpCore, it should ignore the backslash if no character with special meaning follows it. This commit removes the exception and ignores the backslash for literal strings. This can also be done when the digit after a backslash is greater than 7.