### PR TITLE
Added a reference to the SixLabors license

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,8 @@ We appreciate feedback and contribution to this repo!
 ## License
 
 This software is released under the MIT License. See the [LICENSE](LICENCE.md) file for more info.
+
+PdfSharpCore relies on the following projects, that are not under the MIT license:
+
+* *SixLabors.ImageSharp* and *SixLabors.Fonts*
+  * SixLabors.ImageSharp and SixLabors.Fonts, libraries which PdfSharpCore relies upon, are licensed under Apache 2.0 when distributed as part of PdfSharpCore. The SixLabors.ImageSharp license covers all other usage, see https://github.com/SixLabors/ImageSharp/blob/master/LICENSE


### PR DESCRIPTION
and, as clarification, the text that SixLabors products are licensed
under Apache 2.0, as long as the distributed version is used.