### PR TITLE
Implement missing XForm.Finish() method

### DIFF
--- a/PdfSharpCore/Drawing/XForm.cs
+++ b/PdfSharpCore/Drawing/XForm.cs
@@ -180,7 +180,11 @@ namespace PdfSharpCore.Drawing
             if (_formState == FormState.NotATemplate || _formState == FormState.Finished)
                 return;
 
-            Debug.Assert(_formState == FormState.Created || _formState == FormState.UnderConstruction);
+            if (!(_formState == FormState.Created || _formState == FormState.UnderConstruction))
+            {
+                throw new InvalidOperationException("Expected the form to be Created or UnderConstruction");
+            }
+
             _formState = FormState.Finished;
             Gfx.Dispose();
             Gfx = null;
@@ -189,7 +193,6 @@ namespace PdfSharpCore.Drawing
             {
                 //pdfForm.CreateStream(PdfEncoders.RawEncoding.GetBytes(PdfRenderer.GetContent()));
                 PdfRenderer.Close();
-                Debug.Assert(PdfRenderer == null);
 
                 if (_document.Options.CompressContentStreams)
                 {

--- a/PdfSharpCore/Drawing/XForm.cs
+++ b/PdfSharpCore/Drawing/XForm.cs
@@ -177,6 +177,28 @@ namespace PdfSharpCore.Drawing
         /// </summary>
         internal virtual void Finish()
         {
+            if (_formState == FormState.NotATemplate || _formState == FormState.Finished)
+                return;
+
+            Debug.Assert(_formState == FormState.Created || _formState == FormState.UnderConstruction);
+            _formState = FormState.Finished;
+            Gfx.Dispose();
+            Gfx = null;
+
+            if (PdfRenderer != null)
+            {
+                //pdfForm.CreateStream(PdfEncoders.RawEncoding.GetBytes(PdfRenderer.GetContent()));
+                PdfRenderer.Close();
+                Debug.Assert(PdfRenderer == null);
+
+                if (_document.Options.CompressContentStreams)
+                {
+                    _pdfForm.Stream.Value = Filtering.FlateDecode.Encode(_pdfForm.Stream.Value, _document.Options.FlateEncodeMode);
+                    _pdfForm.Elements["/Filter"] = new PdfName("/FlateDecode");
+                }
+                int length = _pdfForm.Stream.Length;
+                _pdfForm.Elements.SetInteger("/Length", length);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This omission seems accidental (it was entirely wrapped in an `#if gdi` in the original version, but only two lines of it were GDI-only).

The absence of an implementation here was breaking #243. Taken directly from the upstream implementation https://github.com/empira/PDFsharp/blob/3205bd933b464d150c0f42e8bcdff3314b6c6164/src/PdfSharp/Drawing/XForm.cs#L231-L262.