### PR TITLE
Add Strikethrough to Font

### DIFF
--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel/Font.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel/Font.cs
@@ -110,6 +110,9 @@ namespace MigraDocCore.DocumentObjectModel
             if (!font.underline.IsNull && (refFont == null || font.Underline != refFont.Underline))
                 this.Underline = font.Underline;
 
+            if (!font.strikethrough.IsNull && (refFont == null || font.Strikethrough != refFont.Strikethrough))
+                this.Strikethrough = font.Strikethrough;
+
             if (!font.color.IsNull && (refFont == null || font.Color.Argb != refFont.Color.Argb))
                 this.Color = font.Color;
         }
@@ -141,6 +144,9 @@ namespace MigraDocCore.DocumentObjectModel
 
             if (!font.underline.IsNull)
                 this.Underline = font.Underline;
+
+            if (!font.strikethrough.IsNull)
+                this.Strikethrough = font.Strikethrough;
 
             if (!font.color.IsNull)
                 this.Color = font.Color;
@@ -243,6 +249,15 @@ namespace MigraDocCore.DocumentObjectModel
         }
         [DV]
         internal NBool subscript = NBool.NullValue;
+
+
+        public Strikethrough Strikethrough
+        {
+            get { return (Strikethrough)this.strikethrough.Value; }
+            set { this.strikethrough.Value = (int)value; }
+        }
+        [DV(Type = typeof(Strikethrough))]
+        internal NEnum strikethrough = NEnum.NullValue(typeof(Strikethrough));
 
         //  + .Name = "Verdana"
         //  + .Size = 8
@@ -362,6 +377,9 @@ namespace MigraDocCore.DocumentObjectModel
                 if (!this.underline.IsNull)
                     serializer.WriteSimpleAttribute("Underline", this.Underline);
 
+                if (!this.strikethrough.IsNull)
+                    serializer.WriteSimpleAttribute("Strikethrough", this.Strikethrough);
+
                 if (!this.superscript.IsNull)
                     serializer.WriteSimpleAttribute("Superscript", this.Superscript);
 
@@ -398,6 +416,9 @@ namespace MigraDocCore.DocumentObjectModel
 
                 if (!underline.IsNull && (font == null || Underline != font.Underline || font.underline.IsNull))
                     serializer.WriteSimpleAttribute("Underline", Underline);
+
+                if (!strikethrough.IsNull && (font == null || Strikethrough != font.Strikethrough || font.strikethrough.IsNull))
+                    serializer.WriteSimpleAttribute("Strikethrough", Strikethrough);
 
                 if (!superscript.IsNull && (font == null || Superscript != font.Superscript || font.superscript.IsNull))
                     serializer.WriteSimpleAttribute("Superscript", Superscript);

--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel/Styles.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel/Styles.cs
@@ -228,6 +228,7 @@ namespace MigraDocCore.DocumentObjectModel
             style.Font.Color = Colors.Black;
             style.Font.Subscript = false;
             style.Font.Superscript = false;
+            style.Font.Strikethrough = Strikethrough.None;
             style.ParagraphFormat.Alignment = ParagraphAlignment.Left;
             style.ParagraphFormat.FirstLineIndent = 0;
             style.ParagraphFormat.LeftIndent = 0;

--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel/enums/Strikethrough.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel/enums/Strikethrough.cs
@@ -1,0 +1,66 @@
+﻿#region MigraDoc - Creating Documents on the Fly
+//
+// Authors:
+//   Stefan Lange (mailto:Stefan.Lange@PdfSharpCore.com)
+//   Klaus Potzesny (mailto:Klaus.Potzesny@PdfSharpCore.com)
+//   David Stephensen (mailto:David.Stephensen@PdfSharpCore.com)
+//
+// Copyright (c) 2001-2009 empira Software GmbH, Cologne (Germany)
+//
+// http://www.PdfSharpCore.com
+// http://www.migradoc.com
+// http://sourceforge.net/projects/pdfsharp
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MigraDocCore.DocumentObjectModel
+{
+    /// <summary>
+    /// Specify the strike out type for font
+    /// </summary>
+    public enum Strikethrough
+    {
+        None,
+        Single,
+        Words,
+        Dotted,
+        Dash,
+        DotDash,
+        DotDotDash,
+
+        /* --- unsupported ---
+        Double          = 3,
+        Thick           = 6,
+        Wavy            = 11,
+        WavyHeavy       = 27,
+        DottedHeavy     = 20,
+        DashHeavy       = 23,
+        DotDashHeavy    = 25,
+        DotDotDashHeavy = 26,
+        DashLong        = 39,
+        DashLongHeavy   = 55,
+        WavyDouble      = 43
+        */
+    }
+}

--- a/MigraDocCore.Rendering/MigraDoc.Rendering.ChartMapper/FontMapper.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering.ChartMapper/FontMapper.cs
@@ -60,6 +60,7 @@ namespace MigraDocCore.Rendering.ChartMapper
         font.Size = domFont.Size.Point;
       font.Subscript = domFont.Subscript;
       font.Superscript = domFont.Superscript;
+      font.Strikethrough = (Strikethrough)domFont.Strikethrough;
       font.Underline = (Underline)domFont.Underline;
     }
 

--- a/MigraDocCore.Rendering/MigraDoc.Rendering.UnitTest/TestParagraphRenderer.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering.UnitTest/TestParagraphRenderer.cs
@@ -48,7 +48,7 @@ namespace MigraDocCore.Rendering.UnitTest
 
         internal static void FillFormattedParagraph(Paragraph par)
         {
-            for (int idx = 0; idx <= 140; ++idx)
+            for (int idx = 0; idx <= 200; ++idx)
             {
                 if (idx < 60)
                 {
@@ -61,12 +61,42 @@ namespace MigraDocCore.Rendering.UnitTest
                     par.AddText((idx).ToString());
                     par.AddText(" ");
                 }
-                else
+                else if (idx < 140)
                 {
                     FormattedText formText = par.AddFormattedText((idx).ToString(), TextFormat.Italic);
                     formText.Font.Size = 6;
                     formText.AddText(" ");
                 }
+                // Strikethrough tests
+                else if (idx < 150)
+                {
+                    FormattedText formText = par.AddFormattedText((idx).ToString());
+                    formText.Font.Size = 16;
+                    formText.Font.Strikethrough = Strikethrough.Single;
+                    formText.AddText(" ");
+                }
+                else if (idx < 160)
+                {
+                    FormattedText formText = par.AddFormattedText((idx).ToString());
+                    formText.Font.Size = 8;
+                    formText.Font.Strikethrough = Strikethrough.DotDash;
+                    formText.AddText(" ");
+                }
+                else if (idx < 170)
+                {
+                    FormattedText formText = par.AddFormattedText((idx).ToString());
+                    formText.Font.Size = 14;
+                    formText.Font.Strikethrough = Strikethrough.DotDotDash;
+                    formText.AddText(" ");
+                }
+                else if (idx < 180)
+                {
+                    FormattedText formText = par.AddFormattedText((idx).ToString());
+                    formText.Font.Size = 20;
+                    formText.Font.Strikethrough = Strikethrough.Dotted;
+                    formText.AddText(" ");
+                }
+
                 if (idx % 50 == 0)
                     par.AddLineBreak();
             }

--- a/PdfSharpCore.Charting/PdfSharp.Charting/Font.cs
+++ b/PdfSharpCore.Charting/PdfSharp.Charting/Font.cs
@@ -123,6 +123,16 @@ namespace PdfSharpCore.Charting
     internal Underline underline;
 
     /// <summary>
+    /// Gets or sets the strikethrough property.
+    /// </summary>
+    public Strikethrough Strikethrough
+    {
+      get { return this.strikethrough; }
+      set { this.strikethrough = value; }
+    }
+    internal Strikethrough strikethrough;
+
+    /// <summary>
     /// Gets or sets the color property.
     /// </summary>
     public XColor Color

--- a/PdfSharpCore.Charting/PdfSharp.Charting/enums/Strikethrough.cs
+++ b/PdfSharpCore.Charting/PdfSharp.Charting/enums/Strikethrough.cs
@@ -1,0 +1,63 @@
+﻿#region PDFsharp Charting - A .NET charting library based on PDFsharp
+//
+// Authors:
+//   Niklas Schneider (mailto:Niklas.Schneider@PdfSharpCore.com)
+//
+// Copyright (c) 2005-2009 empira Software GmbH, Cologne (Germany)
+//
+// http://www.PdfSharpCore.com
+// http://sourceforge.net/projects/pdfsharp
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PdfSharpCore.Charting
+{
+    /// <summary>
+    /// Specify the strike out type for font
+    /// </summary>
+    public enum Strikethrough
+    {
+        None,
+        Single,
+        Words,
+        Dotted,
+        Dash,
+        DotDash,
+        DotDotDash,
+
+        /* --- unsupported ---
+        Double          = 3,
+        Thick           = 6,
+        Wavy            = 11,
+        WavyHeavy       = 27,
+        DottedHeavy     = 20,
+        DashHeavy       = 23,
+        DotDashHeavy    = 25,
+        DotDotDashHeavy = 26,
+        DashLong        = 39,
+        DashLongHeavy   = 55,
+        WavyDouble      = 43
+        */
+    }
+}


### PR DESCRIPTION
Add the ability to mark font as striked out using new property in font.
Similar to Underline functionality.

I didn't find any posibility to add striked out text in MigraDocCore...Document before rendering to PdfDocument, so i desided to implement it in, like were disscussed here: https://forum.pdfsharp.net/viewtopic.php?f=2&t=1021
But i don't think it's linked to underline it self, soo i've add property to Font.