### PR TITLE
Implement missing PdfDocument.Flatten() method

### DIFF
--- a/PdfSharpCore/Pdf/PdfDocument.cs
+++ b/PdfSharpCore/Pdf/PdfDocument.cs
@@ -799,9 +799,9 @@ namespace PdfSharpCore.Pdf
         }
 
         /// <summary>
-        /// Flattens a document (make the fields non-editable).
+        /// Marks the acroform fields readonly 
         /// </summary>
-        public void Flatten()
+        public void MakeAcroFormsReadOnly()
         {
             for (var i = 0; i < AcroForm?.Fields.Count(); i++)
             {

--- a/PdfSharpCore/Pdf/PdfDocument.cs
+++ b/PdfSharpCore/Pdf/PdfDocument.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using PdfSharpCore.Pdf.Advanced;
 using PdfSharpCore.Pdf.Internal;
 using PdfSharpCore.Pdf.IO;
@@ -795,6 +796,17 @@ namespace PdfSharpCore.Pdf
             if (!CanModify)
                 throw new InvalidOperationException(PSSR.CannotModify);
             return Catalog.Pages.Insert(index, page, annotationCopying);
+        }
+
+        /// <summary>
+        /// Flattens a document (make the fields non-editable).
+        /// </summary>
+        public void Flatten()
+        {
+            for (var i = 0; i < AcroForm?.Fields.Count(); i++)
+            {
+                AcroForm.Fields[i].ReadOnly = true;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Was refactoring a .NET framework project to .NET core and stumbled upon this missing method.

Ported it over from PdfSharp.