### PR TITLE
Changed PdfPage contructor to take MediaBox dimensions into account 

### DIFF
--- a/PdfSharpCore/Pdf/PdfPage.cs
+++ b/PdfSharpCore/Pdf/PdfPage.cs
@@ -72,7 +72,8 @@ namespace PdfSharpCore.Pdf
         {
             // Set Orientation depending on /Rotate.
             int rotate = Elements.GetInteger(InheritablePageKeys.Rotate);
-            if (Math.Abs((rotate / 90)) % 2 == 1)
+            var mediaBox = Elements.GetArray(InheritablePageKeys.MediaBox);
+            if (Math.Abs((rotate / 90)) % 2 == 1 && mediaBox.Elements.GetReal(3) > mediaBox.Elements.GetReal(2))
                 _orientation = PageOrientation.Landscape;
         }
 


### PR DESCRIPTION
I've expanded the condition that sets orientation in PdfPage constructor. For Landscape value to be set, MediaBox height must be higher than width when it is rotated 90 degrees left or right.