### PR TITLE
fix (Build): remove deprecated net5.0; drop netcoreapp3.1 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,12 @@ jobs:
       matrix:
         options:
           - framework: net6.0
-          - framework: net5.0
-          - framework: netcoreapp3.1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: DotNetBuild
         shell: pwsh
         run: ./ci-build.ps1 "${{matrix.options.framework}}"
       - name: Test
         run: dotnet test --no-restore --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
       - name: Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3

--- a/MigraDocCore.DocumentObjectModel/MigraDocCore.DocumentObjectModel.csproj
+++ b/MigraDocCore.DocumentObjectModel/MigraDocCore.DocumentObjectModel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>
     <Description>MigraDocCore.DocumentObjectModel for .NET Core MigraDocCore.DocumentObjectModel was ported from MigraDoc version 1.32</Description>

--- a/MigraDocCore.Rendering/MigraDocCore.Rendering.csproj
+++ b/MigraDocCore.Rendering/MigraDocCore.Rendering.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>
     <Description>MigraDocCore.Rendering for .NET Core

--- a/PdfSharpCore.Charting/PdfSharpCore.Charting.csproj
+++ b/PdfSharpCore.Charting/PdfSharpCore.Charting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>
     <Description>PdfSharpCore.Charting for .NET Core PdfSharpCore.Charting was ported from PdfSharp</Description>

--- a/PdfSharpCore.Test/PdfSharpCore.Test.csproj
+++ b/PdfSharpCore.Test/PdfSharpCore.Test.csproj
@@ -1,23 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/PdfSharpCore/Drawing/XGraphics.cs
+++ b/PdfSharpCore/Drawing/XGraphics.cs
@@ -123,9 +123,6 @@ namespace PdfSharpCore.Drawing  // #??? aufräumen
         }
         XGraphics(XSize size, XGraphicsUnit pageUnit, XPageDirection pageDirection)
         {
-            if (size == null)
-                throw new ArgumentNullException("size");
-
             _gsStack = new GraphicsStateStack(this);
             _pageSizePoints = new XSize(size.Width, size.Height);
             switch (pageUnit)

--- a/PdfSharpCore/Pdf.AcroForms/PdfSignatureField.cs
+++ b/PdfSharpCore/Pdf.AcroForms/PdfSignatureField.cs
@@ -56,7 +56,7 @@ namespace PdfSharpCore.Pdf.AcroForms
             /// must be Sig for a signature dictionary.
             /// </summary>
             [KeyInfo(KeyType.Name | KeyType.Optional)]
-            public const string Type = "/Type";
+            public new const string Type = "/Type";
 
             /// <summary>
             /// (Required; inheritable) The name of the signature handler to be used for

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>
     <Description>PdfSharp for .NET Core

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<IsTrimmable>true</IsTrimmable>


### PR DESCRIPTION
## Changes
- remove deprecated net5.0 target
- remove netcoreapp 3.1 target  (both still compatible via netstandard2.0 build)
 - Github action scripts updated to remove node12 deprecated warning

## Fixes
- Remove always false check in XGraphics (Build warning)
- Set new on override const in PdfSignatureField  (Build warning)
