### PR TITLE
Added method to get RenderInfo

### DIFF
--- a/MigraDocCore.Rendering/MigraDoc.Rendering/Area.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/Area.cs
@@ -36,7 +36,7 @@ namespace MigraDocCore.Rendering
   /// <summary>
   /// Abstract base class for all areas to render in.
   /// </summary>
-  internal abstract class Area
+  public abstract class Area
   {
     internal Area()
     {
@@ -45,7 +45,7 @@ namespace MigraDocCore.Rendering
     /// <summary>
     /// Gets the left boundary of the area.
     /// </summary>
-    internal abstract XUnit X
+    public abstract XUnit X
     {
       get;
       set;
@@ -54,7 +54,7 @@ namespace MigraDocCore.Rendering
     /// <summary>
     /// Gets the top boundary of the area.
     /// </summary>
-    internal abstract XUnit Y
+    public abstract XUnit Y
     {
       get;
       set;
@@ -74,7 +74,7 @@ namespace MigraDocCore.Rendering
     /// <summary>
     /// Gets or sets the height of the smallest rectangle containing the area. 
     /// </summary>
-    internal abstract XUnit Height
+    public abstract XUnit Height
     {
       get;
       set;
@@ -83,7 +83,7 @@ namespace MigraDocCore.Rendering
     /// <summary>
     /// Gets or sets the width of the smallest rectangle containing the area. 
     /// </summary>
-    internal abstract XUnit Width
+    public abstract XUnit Width
     {
       get;
       set;
@@ -152,7 +152,7 @@ namespace MigraDocCore.Rendering
     /// <summary>
     /// Gets or sets the left boundary of the rectangle. 
     /// </summary>
-    internal override XUnit X
+    public override XUnit X
     {
       get { return this.x; }
       set { this.x = value; }
@@ -162,7 +162,7 @@ namespace MigraDocCore.Rendering
     /// <summary>
     /// Gets or sets the top boundary of the rectangle. 
     /// </summary>
-    internal override XUnit Y
+    public override XUnit Y
     {
       get { return this.y; }
       set { this.y = value; }
@@ -172,7 +172,7 @@ namespace MigraDocCore.Rendering
     /// <summary>
     /// Gets or sets the top boundary of the rectangle. 
     /// </summary>
-    internal override XUnit Width
+    public override XUnit Width
     {
       get { return this.width; }
       set { this.width = value; }
@@ -182,7 +182,7 @@ namespace MigraDocCore.Rendering
     /// <summary>
     /// Gets or sets the height of the rectangle. 
     /// </summary>
-    internal override XUnit Height
+    public override XUnit Height
     {
       get { return this.height; }
       set { this.height = value; }

--- a/MigraDocCore.Rendering/MigraDoc.Rendering/DocumentRenderer.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/DocumentRenderer.cs
@@ -175,6 +175,14 @@ namespace MigraDocCore.Rendering
         }
 
         /// <summary>
+        /// Gets the render information for document objects that get rendered on the specified page.
+        /// </summary>
+        public RenderInfo[] GetRenderInfoFromPage(int page)
+        {
+            return this.formattedDocument.GetRenderInfos(page);
+        }
+
+        /// <summary>
         /// Renders a single object to the specified graphics object at the given point.
         /// </summary>
         /// <param name="graphics">The graphics object to render on.</param>

--- a/MigraDocCore.Rendering/MigraDoc.Rendering/LayoutInfo.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/LayoutInfo.cs
@@ -36,7 +36,7 @@ namespace MigraDocCore.Rendering
   /// <summary>
   /// Abstract base class to serve as a layoutable unit.
   /// </summary>
-  internal class LayoutInfo
+  public class LayoutInfo
   {
     internal LayoutInfo()
     {
@@ -125,7 +125,7 @@ namespace MigraDocCore.Rendering
     /// <summary>
     /// Gets or sets the Area needed by the content (including padding and borders for e.g. paragraphs).
     /// </summary>
-    internal Area ContentArea
+    public Area ContentArea
     {
       get { return this.contentArea; }
       set { this.contentArea = value; }

--- a/MigraDocCore.Rendering/MigraDoc.Rendering/PageBreakRenderInfo.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/PageBreakRenderInfo.cs
@@ -47,7 +47,7 @@ namespace MigraDocCore.Rendering
     }
     internal PageBreakFormatInfo pageBreakFormatInfo;
 
-    internal override DocumentObject DocumentObject
+    public override DocumentObject DocumentObject
     {
       get { return this.pageBreak; }
     }

--- a/MigraDocCore.Rendering/MigraDoc.Rendering/ParagraphRenderInfo.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/ParagraphRenderInfo.cs
@@ -47,7 +47,7 @@ namespace MigraDocCore.Rendering
     }
     ParagraphFormatInfo formatInfo = new ParagraphFormatInfo();
 
-    internal override DocumentObject DocumentObject
+    public override DocumentObject DocumentObject
     {
       get { return this.paragraph; }
     }

--- a/MigraDocCore.Rendering/MigraDoc.Rendering/RenderInfo.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/RenderInfo.cs
@@ -37,20 +37,20 @@ namespace MigraDocCore.Rendering
   /// <summary>
   /// Abstract base class for all classes that store rendering information.
   /// </summary>
-  internal abstract class RenderInfo
+  public abstract class RenderInfo
   {
     internal abstract FormatInfo FormatInfo
     {
       get;
     }
 
-    internal LayoutInfo LayoutInfo
+    public LayoutInfo LayoutInfo
     {
       get { return this.layoutInfo; }
     }
     LayoutInfo layoutInfo = new LayoutInfo();
 
-    internal abstract DocumentObject DocumentObject
+    public abstract DocumentObject DocumentObject
     {
       get;
     }

--- a/MigraDocCore.Rendering/MigraDoc.Rendering/ShapeRenderInfo.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/ShapeRenderInfo.cs
@@ -44,7 +44,7 @@ namespace MigraDocCore.Rendering
     {
     }
 
-    internal override DocumentObject DocumentObject
+    public override DocumentObject DocumentObject
     {
       get { return this.shape; }
     }

--- a/MigraDocCore.Rendering/MigraDoc.Rendering/TableRenderInfo.cs
+++ b/MigraDocCore.Rendering/MigraDoc.Rendering/TableRenderInfo.cs
@@ -49,7 +49,7 @@ namespace MigraDocCore.Rendering
     }
     private TableFormatInfo formatInfo = new TableFormatInfo();
 
-    internal override DocumentObject DocumentObject
+    public override DocumentObject DocumentObject
     {
       get { return this.table; }
     }


### PR DESCRIPTION
For some modifications of the pdf file the RenderInfo DocumentObjects and LayoutInfos are necessary. 

### Changes

Added the method GetRenderInfoFromPage() like in the [original MigraDoc DocumentRenderer.cs](https://github.com/empira/MigraDoc/blob/master/MigraDoc/src/MigraDoc.Rendering/Rendering/DocumentRenderer.cs)
Therefore some Classes had to be made public - like they are already in the original MigraDoc.

### Fixes

This fixes several points:

- #210 
- #224 
- maybe also #221  

I tried it on my local build in my existing application and it works like expected.

