### PR TITLE
Add support to ImageSharp 3.x

### DIFF
--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>
     <Description>PdfSharp for .NET Core
@@ -25,6 +25,7 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
 	<PropertyGroup>
         <!--skip warning due to skiplabours.fonts being beta -->
 		<NoWarn>NU5104</NoWarn>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -46,7 +47,7 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta17" />
   </ItemGroup>
 	

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>
     <Description>PdfSharp for .NET Core
@@ -47,7 +47,11 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" Condition="'$(TargetFramework)' == 'netstandard2.0' " />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" Condition="'$(TargetFramework)' == 'netcoreapp3.1' " />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" Condition="'$(TargetFramework)' == 'net5.0' " />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" Condition="'$(TargetFramework)' == 'net6.0' " />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" Condition="'$(TargetFramework)' == 'net7.0' " />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta17" />
   </ItemGroup>
 	

--- a/PdfSharpCore/Utils/ImageSharpImageSource.cs
+++ b/PdfSharpCore/Utils/ImageSharpImageSource.cs
@@ -22,16 +22,27 @@ namespace PdfSharpCore.Utils
 
         protected override IImageSource FromBinaryImpl(string name, Func<byte[]> imageSource, int? quality = 75)
         {
+
+#if NET6_0 || NET7_0
             var image = Image.Load<TPixel>(imageSource.Invoke());
             var imgFormat = image.Metadata.DecodedImageFormat;
+#else
+            var image = Image.Load<TPixel>(imageSource.Invoke(), out IImageFormat imgFormat);
+#endif
 
             return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
         }
 
         protected override IImageSource FromFileImpl(string path, int? quality = 75)
         {
+
+#if NET6_0 || NET7_0
             var image = Image.Load<TPixel>(path);
             var imgFormat = image.Metadata.DecodedImageFormat;
+#else
+            var image = Image.Load<TPixel>(path, out IImageFormat imgFormat);
+#endif
+
             return new ImageSharpImageSourceImpl<TPixel>(path, image, (int) quality, imgFormat is PngFormat);
         }
 
@@ -39,8 +50,13 @@ namespace PdfSharpCore.Utils
         {
             using (var stream = imageStream.Invoke())
             {
+
+#if NET6_0 || NET7_0
                 var image = Image.Load<TPixel>(stream);
                 var imgFormat = image.Metadata.DecodedImageFormat;
+#else
+                var image = Image.Load<TPixel>(stream, out IImageFormat imgFormat);
+#endif
                 return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
             }
         }

--- a/PdfSharpCore/Utils/ImageSharpImageSource.cs
+++ b/PdfSharpCore/Utils/ImageSharpImageSource.cs
@@ -3,6 +3,7 @@ using SixLabors.ImageSharp.PixelFormats;
 using MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes;
 using System;
 using System.IO;
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Jpeg;
@@ -21,13 +22,16 @@ namespace PdfSharpCore.Utils
 
         protected override IImageSource FromBinaryImpl(string name, Func<byte[]> imageSource, int? quality = 75)
         {
-            var image = Image.Load<TPixel>(imageSource.Invoke(), out IImageFormat imgFormat);
+            var image = Image.Load<TPixel>(imageSource.Invoke());
+            var imgFormat = image.Metadata.DecodedImageFormat;
+
             return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
         }
 
         protected override IImageSource FromFileImpl(string path, int? quality = 75)
         {
-            var image = Image.Load<TPixel>(path, out IImageFormat imgFormat);
+            var image = Image.Load<TPixel>(path);
+            var imgFormat = image.Metadata.DecodedImageFormat;
             return new ImageSharpImageSourceImpl<TPixel>(path, image, (int) quality, imgFormat is PngFormat);
         }
 
@@ -35,7 +39,8 @@ namespace PdfSharpCore.Utils
         {
             using (var stream = imageStream.Invoke())
             {
-                var image = Image.Load<TPixel>(stream, out IImageFormat imgFormat);
+                var image = Image.Load<TPixel>(stream);
+                var imgFormat = image.Metadata.DecodedImageFormat;
                 return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
             }
         }


### PR DESCRIPTION
This PR add support to ImageSharp 3.x for .net 6.0 and .net 7.0.