### PR TITLE
Added condition, which checks /rotate when modifying landscape PDFs

### DIFF
--- a/PdfSharpCore/Pdf/PdfPage.cs
+++ b/PdfSharpCore/Pdf/PdfPage.cs
@@ -592,8 +592,7 @@ namespace PdfSharpCore.Pdf
         {
             // HACK: temporarily flip media box if Landscape
             PdfRectangle mediaBox = MediaBox;
-            // TODO: Take /Rotate into account
-            if (_orientation == PageOrientation.Landscape)
+            if (_orientation == PageOrientation.Landscape && Math.Abs(Rotate / 90) % 2 == 0)
                 MediaBox = new PdfRectangle(mediaBox.X1, mediaBox.Y1, mediaBox.Y2, mediaBox.X2);
 
 #if true


### PR DESCRIPTION
This fixes an issue, where PDFs which have landscape orientation when rotated 90 or 270 degrees could have their dimensions flipped if they were modified.