### PR TITLE
Fix for Turkish culture crash

### DIFF
--- a/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Internals/DomValueDescriptorCollection.cs
+++ b/MigraDocCore.DocumentObjectModel/MigraDoc.DocumentObjectModel.Internals/DomValueDescriptorCollection.cs
@@ -90,6 +90,6 @@ namespace MigraDocCore.DocumentObjectModel.Internals
     }
 
     ArrayList arrayList = new ArrayList();
-    Hashtable hashTable = new Hashtable(StringComparer.CurrentCultureIgnoreCase);
+    Hashtable hashTable = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
   }
 }

--- a/PdfSharpCore.Test/MigradocTurkishTest.cs
+++ b/PdfSharpCore.Test/MigradocTurkishTest.cs
@@ -1,0 +1,41 @@
+﻿using MigraDocCore.Rendering;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+using MigraDocCore.DocumentObjectModel;
+
+namespace PdfSharpCore.Test
+{
+    public class MigradocTurkishTest
+    {
+        private CultureInfo originalCulture;
+        private CultureInfo originalUICulture;
+
+        [Fact]
+        public void RenderDocument_TurkishCulture_NoCrashing()
+        {
+            originalCulture = Thread.CurrentThread.CurrentCulture;
+            originalUICulture = Thread.CurrentThread.CurrentUICulture;
+            var cultureInfo = CultureInfo.GetCultureInfo("tr-TR");
+            Thread.CurrentThread.CurrentCulture = cultureInfo;
+            Thread.CurrentThread.CurrentUICulture = cultureInfo;
+
+            try
+            {
+                Document doc = new Document();
+                PdfDocumentRenderer printer = new PdfDocumentRenderer() { Document = doc };
+                printer.RenderDocument();
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+                Thread.CurrentThread.CurrentUICulture = originalUICulture;
+                CultureInfo.CurrentCulture.ClearCachedData();
+                CultureInfo.CurrentUICulture.ClearCachedData();
+            }
+        }
+    }
+}

--- a/PdfSharpCore.Test/PdfSharpCore.Test.csproj
+++ b/PdfSharpCore.Test/PdfSharpCore.Test.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\PdfSharpCore\PdfSharpCore.csproj" />
+    <ProjectReference Include="..\MigraDocCore.Rendering\MigraDocCore.Rendering.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PdfSharpCore/Fonts/GlobalFontSettings.cs
+++ b/PdfSharpCore/Fonts/GlobalFontSettings.cs
@@ -57,8 +57,13 @@ namespace PdfSharpCore.Fonts
         {
             get 
             {
-                if (_fontResolver == null) FontResolver = new FontResolver();
-                    return _fontResolver; 
+                try
+                {
+                    Lock.EnterFontFactory();
+                    if (_fontResolver == null) FontResolver = new FontResolver();
+                        return _fontResolver;
+                }
+                finally { Lock.ExitFontFactory(); }
             }
             set
             {


### PR DESCRIPTION
closes #375
Fixes a crash in PdfDocumentRenderer under culture "tr-TR" and adds a unit test for it. Also fixes a race-condition in GlobalFontSettings that was preventing the unit test from running.