### PR TITLE
Fixes https://github.com/ststeiger/PdfSharpCore/issues/399

### DIFF
--- a/MigraDocCore.DocumentObjectModel/MigraDocCore.DocumentObjectModel.csproj
+++ b/MigraDocCore.DocumentObjectModel/MigraDocCore.DocumentObjectModel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>

--- a/MigraDocCore.Rendering/MigraDocCore.Rendering.csproj
+++ b/MigraDocCore.Rendering/MigraDocCore.Rendering.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>

--- a/PdfSharpCore.Charting/PdfSharpCore.Charting.csproj
+++ b/PdfSharpCore.Charting/PdfSharpCore.Charting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>

--- a/PdfSharpCore.Test/CreateSimplePDF.cs
+++ b/PdfSharpCore.Test/CreateSimplePDF.cs
@@ -88,11 +88,11 @@ namespace PdfSharpCore.Test
             var renderer = XGraphics.FromPdfPage(pageNewRenderer);
 
             // Load image for ImageSharp and apply a simple mutation:
-            var image = Image.Load<Rgb24>(PathHelper.GetInstance().GetAssetPath("lenna.png"), out var format);
+            var image = Image.Load<Rgb24>(PathHelper.GetInstance().GetAssetPath("lenna.png"));
             image.Mutate(ctx => ctx.Grayscale());
 
             // create XImage from that same ImageSharp image:
-            var source = ImageSharpImageSource<Rgb24>.FromImageSharpImage(image, format);
+            var source = ImageSharpImageSource<Rgb24>.FromImageSharpImage(image, image.Metadata.DecodedImageFormat);
             var img = XImage.FromImageSource(source);
 
             renderer.DrawImage(img, new XPoint(0, 0));

--- a/PdfSharpCore.Test/PdfSharpCore.Test.csproj
+++ b/PdfSharpCore.Test/PdfSharpCore.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -21,6 +21,7 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
 	  <AssemblyVersion>1.3.63</AssemblyVersion>
 	  <PackageVersion>1.3.63</PackageVersion>
 	  <FileVersion>1.3.63</FileVersion>
+	  <ProductVersion>1.3.63</ProductVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -17,6 +17,10 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
     <summary>PdfSharp for .NET Core</summary>
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+
+	  <AssemblyVersion>1.3.63</AssemblyVersion>
+	  <PackageVersion>1.3.63</PackageVersion>
+	  <FileVersion>1.3.63</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -46,9 +50,9 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
     <Folder Include="Resources\images\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta17" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
+    <PackageReference Include="SixLabors.Fonts" Version="2.0.0" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/PdfSharpCore/Utils/ImageSharpImageSource.cs
+++ b/PdfSharpCore/Utils/ImageSharpImageSource.cs
@@ -7,6 +7,7 @@ using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Advanced;
 
 namespace PdfSharpCore.Utils
 {
@@ -21,21 +22,26 @@ namespace PdfSharpCore.Utils
 
         protected override IImageSource FromBinaryImpl(string name, Func<byte[]> imageSource, int? quality = 75)
         {
-            var image = Image.Load<TPixel>(imageSource.Invoke(), out IImageFormat imgFormat);
+            var image = Image.Load<TPixel>(imageSource.Invoke());
+            var imgFormat = image.Metadata.DecodedImageFormat;
+
             return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
         }
 
         protected override IImageSource FromFileImpl(string path, int? quality = 75)
         {
-            var image = Image.Load<TPixel>(path, out IImageFormat imgFormat);
+            var image = Image.Load<TPixel>(path);
+            var imgFormat = image.Metadata.DecodedImageFormat;
+
             return new ImageSharpImageSourceImpl<TPixel>(path, image, (int) quality, imgFormat is PngFormat);
         }
 
-        protected override IImageSource FromStreamImpl(string name, Func<Stream> imageStream, int? quality = 75)
-        {
-            using (var stream = imageStream.Invoke())
-            {
-                var image = Image.Load<TPixel>(stream, out IImageFormat imgFormat);
+        protected override IImageSource FromStreamImpl(string name, Func<Stream> imageStream, int? quality = 75) 
+        { 
+            using (var stream = imageStream.Invoke()) {
+                var image = Image.Load<TPixel>(stream);
+                var imgFormat = image.Metadata.DecodedImageFormat;
+
                 return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
             }
         }

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
This fixes https://github.com/ststeiger/PdfSharpCore/issues/399 and removes unsupported .NET versions.