### PR TITLE
Update target frameworks to only include .NET 6.0 and Upgrade Six Lab…

### DIFF
--- a/MigraDocCore.DocumentObjectModel/MigraDocCore.DocumentObjectModel.csproj
+++ b/MigraDocCore.DocumentObjectModel/MigraDocCore.DocumentObjectModel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>

--- a/MigraDocCore.Rendering/MigraDocCore.Rendering.csproj
+++ b/MigraDocCore.Rendering/MigraDocCore.Rendering.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>

--- a/PdfSharpCore.Charting/PdfSharpCore.Charting.csproj
+++ b/PdfSharpCore.Charting/PdfSharpCore.Charting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>

--- a/PdfSharpCore.Test/CreateSimplePDF.cs
+++ b/PdfSharpCore.Test/CreateSimplePDF.cs
@@ -88,11 +88,13 @@ namespace PdfSharpCore.Test
             var renderer = XGraphics.FromPdfPage(pageNewRenderer);
 
             // Load image for ImageSharp and apply a simple mutation:
-            var image = Image.Load<Rgb24>(PathHelper.GetInstance().GetAssetPath("lenna.png"), out var format);
+            var image = Image.Load<Rgb24>(PathHelper.GetInstance().GetAssetPath("lenna.png"));
             image.Mutate(ctx => ctx.Grayscale());
 
+            var imageInfo = Image.Identify(PathHelper.GetInstance().GetAssetPath("lenna.png"));
+
             // create XImage from that same ImageSharp image:
-            var source = ImageSharpImageSource<Rgb24>.FromImageSharpImage(image, format);
+            var source = ImageSharpImageSource<Rgb24>.FromImageSharpImage(image, imageInfo.Metadata.DecodedImageFormat);
             var img = XImage.FromImageSource(source);
 
             renderer.DrawImage(img, new XPoint(0, 0));

--- a/PdfSharpCore.Test/PdfSharpCore.Test.csproj
+++ b/PdfSharpCore.Test/PdfSharpCore.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>
@@ -47,8 +47,8 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta17" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
+    <PackageReference Include="SixLabors.Fonts" Version="2.0.0" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/PdfSharpCore/Utils/ImageSharpImageSource.cs
+++ b/PdfSharpCore/Utils/ImageSharpImageSource.cs
@@ -3,6 +3,7 @@ using SixLabors.ImageSharp.PixelFormats;
 using MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes;
 using System;
 using System.IO;
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Jpeg;
@@ -21,22 +22,27 @@ namespace PdfSharpCore.Utils
 
         protected override IImageSource FromBinaryImpl(string name, Func<byte[]> imageSource, int? quality = 75)
         {
-            var image = Image.Load<TPixel>(imageSource.Invoke(), out IImageFormat imgFormat);
-            return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
+            var readOnlySpan = imageSource.Invoke();
+            var image = Image.Load<TPixel>(readOnlySpan);
+            var imageInfo = Image.Identify(readOnlySpan);
+            return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imageInfo.Metadata.DecodedImageFormat is PngFormat);
         }
 
         protected override IImageSource FromFileImpl(string path, int? quality = 75)
         {
-            var image = Image.Load<TPixel>(path, out IImageFormat imgFormat);
-            return new ImageSharpImageSourceImpl<TPixel>(path, image, (int) quality, imgFormat is PngFormat);
+            var image = Image.Load<TPixel>(path);
+            var imageInfo = Image.Identify(path);
+            return new ImageSharpImageSourceImpl<TPixel>(path, image, (int) quality, imageInfo.Metadata.DecodedImageFormat is PngFormat);
         }
 
         protected override IImageSource FromStreamImpl(string name, Func<Stream> imageStream, int? quality = 75)
         {
             using (var stream = imageStream.Invoke())
             {
-                var image = Image.Load<TPixel>(stream, out IImageFormat imgFormat);
-                return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
+                var image = Image.Load<TPixel>(stream);
+                var imageInfo = Image.Identify(stream);
+
+                return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imageInfo.Metadata.DecodedImageFormat is PngFormat);
             }
         }
 

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Targeted latest Six Labor packages to allow upgrading in consumer projects. Targets > .NET 6 due to constraints in Six Labor packages