### PR TITLE
Enable compatibility with old and new image sharp versions.

### DIFF
--- a/MigraDocCore.DocumentObjectModel/MigraDocCore.DocumentObjectModel.csproj
+++ b/MigraDocCore.DocumentObjectModel/MigraDocCore.DocumentObjectModel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>

--- a/MigraDocCore.Rendering/MigraDocCore.Rendering.csproj
+++ b/MigraDocCore.Rendering/MigraDocCore.Rendering.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>

--- a/PdfSharpCore.Test/CreateSimplePDF.cs
+++ b/PdfSharpCore.Test/CreateSimplePDF.cs
@@ -88,7 +88,12 @@ namespace PdfSharpCore.Test
             var renderer = XGraphics.FromPdfPage(pageNewRenderer);
 
             // Load image for ImageSharp and apply a simple mutation:
+#if NET6_0_OR_GREATER
+            var image = Image.Load<Rgb24>(PathHelper.GetInstance().GetAssetPath("lenna.png"));
+            var format = image.Metadata.DecodedImageFormat;
+#else
             var image = Image.Load<Rgb24>(PathHelper.GetInstance().GetAssetPath("lenna.png"), out var format);
+#endif
             image.Mutate(ctx => ctx.Grayscale());
 
             // create XImage from that same ImageSharp image:

--- a/PdfSharpCore.Test/PdfSharpCore.Test.csproj
+++ b/PdfSharpCore.Test/PdfSharpCore.Test.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+	<langversion>latest</langversion>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Stefan Steiger and Contributors</Authors>
@@ -17,6 +17,12 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
     <summary>PdfSharp for .NET Core</summary>
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+
+	  <AssemblyVersion>1.6.0</AssemblyVersion>
+	  <PackageVersion>1.6.0</PackageVersion>
+	  <FileVersion>1.6.0</FileVersion>
+	  <ProductVersion>1.6.0</ProductVersion>
+	  
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -45,11 +51,23 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
   <ItemGroup>
     <Folder Include="Resources\images\" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta17" />
-  </ItemGroup>
+
+	<Choose>
+		<When Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net8.0'">
+			<ItemGroup >
+				<PackageReference Include="SharpZipLib" Version="1.4.2" />
+				<PackageReference Include="SixLabors.Fonts" Version="2.0.2" />
+				<PackageReference Include="SixLabors.ImageSharp" Version="3.1.2" />
+			</ItemGroup>
+		</When>
+		<Otherwise>
+			<ItemGroup>
+				<PackageReference Include="SharpZipLib" Version="1.4.2" />
+				<PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta17" />
+				<PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+			</ItemGroup>
+		</Otherwise>
+	</Choose>
 	
   <ItemGroup>
     <None Include="..\LICENSE.md" Pack="true" PackagePath="" />

--- a/PdfSharpCore/Utils/ImageSharpImageSource.cs
+++ b/PdfSharpCore/Utils/ImageSharpImageSource.cs
@@ -7,40 +7,14 @@ using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Advanced;
 
 namespace PdfSharpCore.Utils
 {
-    public class ImageSharpImageSource<TPixel> : ImageSource where TPixel : unmanaged, IPixel<TPixel>
+    public partial class ImageSharpImageSource<TPixel> : ImageSource where TPixel : unmanaged, IPixel<TPixel>
     {
 
-        public static IImageSource FromImageSharpImage(Image<TPixel> image, IImageFormat imgFormat, int? quality = 75)
-        {
-            var _path = "*" + Guid.NewGuid().ToString("B");
-            return new ImageSharpImageSourceImpl<TPixel>(_path, image, (int)quality, imgFormat is PngFormat);
-        }
-
-        protected override IImageSource FromBinaryImpl(string name, Func<byte[]> imageSource, int? quality = 75)
-        {
-            var image = Image.Load<TPixel>(imageSource.Invoke(), out IImageFormat imgFormat);
-            return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
-        }
-
-        protected override IImageSource FromFileImpl(string path, int? quality = 75)
-        {
-            var image = Image.Load<TPixel>(path, out IImageFormat imgFormat);
-            return new ImageSharpImageSourceImpl<TPixel>(path, image, (int) quality, imgFormat is PngFormat);
-        }
-
-        protected override IImageSource FromStreamImpl(string name, Func<Stream> imageStream, int? quality = 75)
-        {
-            using (var stream = imageStream.Invoke())
-            {
-                var image = Image.Load<TPixel>(stream, out IImageFormat imgFormat);
-                return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
-            }
-        }
-
-        private class ImageSharpImageSourceImpl<TPixel2> : IImageSource where TPixel2 : unmanaged, IPixel<TPixel2>
+        private partial class ImageSharpImageSourceImpl<TPixel2> : IImageSource where TPixel2 : unmanaged, IPixel<TPixel2>
         {
             private Image<TPixel2> Image { get; }
             private readonly int _quality;
@@ -56,11 +30,6 @@ namespace PdfSharpCore.Utils
                 Image = image;
                 _quality = quality;
                 Transparent = isTransparent;
-            }
-
-            public void SaveAsJpeg(MemoryStream ms)
-            {
-                Image.SaveAsJpeg(ms, new JpegEncoder() { Quality = this._quality });
             }
 
             public void Dispose()

--- a/PdfSharpCore/Utils/ImageSharpImageSource_NET6.cs
+++ b/PdfSharpCore/Utils/ImageSharpImageSource_NET6.cs
@@ -1,0 +1,68 @@
+#if NET6_0_OR_GREATER
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes;
+using System;
+using System.IO;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Bmp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Advanced;
+
+namespace PdfSharpCore.Utils
+{
+    public partial class ImageSharpImageSource<TPixel> : ImageSource where TPixel : unmanaged, IPixel<TPixel>
+    {
+
+        public static IImageSource FromImageSharpImage(Image<TPixel> image, IImageFormat imgFormat, int? quality = 75)
+        {
+            var _path = "*" + Guid.NewGuid().ToString("B");
+            return new ImageSharpImageSourceImpl<TPixel>(_path, image, (int)quality, imgFormat is PngFormat);
+        }
+
+        protected override IImageSource FromBinaryImpl(string name, Func<byte[]> imageSource, int? quality = 75)
+        {
+            var image = Image.Load<TPixel>(imageSource.Invoke());
+            var imgFormat = image.Metadata.DecodedImageFormat;
+
+            return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
+        }
+
+        protected override IImageSource FromFileImpl(string path, int? quality = 75)
+        {
+            var image = Image.Load<TPixel>(path);
+            var imgFormat = image.Metadata.DecodedImageFormat;
+
+            return new ImageSharpImageSourceImpl<TPixel>(path, image, (int) quality, imgFormat is PngFormat);
+        }
+
+        protected override IImageSource FromStreamImpl(string name, Func<Stream> imageStream, int? quality = 75) 
+        { 
+            using (var stream = imageStream.Invoke()) {
+                var image = Image.Load<TPixel>(stream);
+                var imgFormat = image.Metadata.DecodedImageFormat;
+
+                return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
+            }
+        }
+
+        private partial class ImageSharpImageSourceImpl<TPixel2>
+        {
+
+            public void SaveAsJpeg(MemoryStream ms)
+            {
+                Image.SaveAsJpeg(ms, new JpegEncoder() {
+                    Quality = this._quality,
+                    ColorType = JpegEncodingColor.YCbCrRatio420,
+                    Interleaved = true,
+                });
+            }
+
+        }
+
+    }
+}
+
+#endif

--- a/PdfSharpCore/Utils/ImageSharpImageSource_NETSTANDARD.cs
+++ b/PdfSharpCore/Utils/ImageSharpImageSource_NETSTANDARD.cs
@@ -1,0 +1,61 @@
+#if !NET6_0_OR_GREATER
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes;
+using System;
+using System.IO;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Bmp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Advanced;
+
+namespace PdfSharpCore.Utils
+{
+    public partial class ImageSharpImageSource<TPixel> : ImageSource where TPixel : unmanaged, IPixel<TPixel>
+    {
+
+        public static IImageSource FromImageSharpImage(Image<TPixel> image, IImageFormat imgFormat, int? quality = 75)
+        {
+            var _path = "*" + Guid.NewGuid().ToString("B");
+            return new ImageSharpImageSourceImpl<TPixel>(_path, image, (int)quality, imgFormat is PngFormat);
+        }
+
+        protected override IImageSource FromBinaryImpl(string name, Func<byte[]> imageSource, int? quality = 75)
+        {
+            var image = Image.Load<TPixel>(imageSource.Invoke(), out IImageFormat imgFormat);
+            return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
+        }
+
+        protected override IImageSource FromFileImpl(string path, int? quality = 75)
+        {
+            var image = Image.Load<TPixel>(path, out IImageFormat imgFormat);
+            return new ImageSharpImageSourceImpl<TPixel>(path, image, (int) quality, imgFormat is PngFormat);
+        }
+
+        protected override IImageSource FromStreamImpl(string name, Func<Stream> imageStream, int? quality = 75)
+        {
+            using (var stream = imageStream.Invoke())
+            {
+                var image = Image.Load<TPixel>(stream, out IImageFormat imgFormat);
+                return new ImageSharpImageSourceImpl<TPixel>(name, image, (int)quality, imgFormat is PngFormat);
+            }
+        }
+
+        private partial class ImageSharpImageSourceImpl<TPixel2>
+        {
+            
+            public void SaveAsJpeg(MemoryStream ms)
+            {
+                Image.SaveAsJpeg(ms, new JpegEncoder() { 
+                    Quality = this._quality,
+                });
+            }
+
+        }
+
+    }
+}
+
+#endif

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+	<langversion>latest</langversion>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
(Only NET60 and above use the new ImageSharp.)
Rebase and Cleanup commits.