### PR TITLE
Handle empty object parsing

### DIFF
--- a/PdfSharpCore/Pdf.IO/Parser.cs
+++ b/PdfSharpCore/Pdf.IO/Parser.cs
@@ -260,6 +260,11 @@ namespace PdfSharpCore.Pdf.IO
                     ParserDiagnostics.HandleUnexpectedToken(_lexer.Token);
                     break;
 
+                case Symbol.EndObj:
+                    pdfObject = new PdfNullObject(_document);
+                    pdfObject.SetObjectID(objectNumber, generationNumber);
+                    return pdfObject;
+
                 default:
                     // Should not come here anymore.
                     ParserDiagnostics.HandleUnexpectedToken(_lexer.Token);


### PR DESCRIPTION
When parsing, there is no handling of empty objects.
For example:
```
13 0 obj
endobj
```
This PR aims to return a null object when parsing an empty one instead of throwing "Unexpected token 'endobj' in PDF stream. The file may be corrupted. If you think this is a bug in PDFsharp, please send us your PDF file.".
