### PR TITLE
Ensure a space before PDF arrays are written, even in non-verbose mode

### DIFF
--- a/PdfSharpCore/Pdf.IO/PdfWriter.cs
+++ b/PdfSharpCore/Pdf.IO/PdfWriter.cs
@@ -57,7 +57,7 @@ namespace PdfSharpCore.Pdf.IO
         public void Close(bool closeUnderlyingStream)
         {
             if (_stream != null && closeUnderlyingStream)
-            _stream.Dispose();
+                _stream.Dispose();
             _stream = null;
         }
 
@@ -577,8 +577,8 @@ namespace PdfSharpCore.Pdf.IO
                     }
                     else
                     {
-                        if (cat == CharCat.Character)
-                            _stream.WriteByte((byte)' ');
+                        //if (cat == CharCat.Character)
+                        _stream.WriteByte((byte)' ');
                     }
                     break;
             }


### PR DESCRIPTION
Fixes #442

According to [the spec](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf), section 7.5.5, the trailer dictionary is shown to be space separated. Unfortunately that's not *explicitly* stated, so perhaps PDF parsers should be able to accept the following line:

```
/ID[<FCEAE9E3BEA9864C83AA492B76687F02><FCEAE9E3BEA9864C83AA492B76687F02>]
```

However, if we think that a space after `/ID` is good, then this PR fixes that.

Before:

<details>
<summary>Before</summary>

```
%PDF-1.4
%����
1 0 obj
<<
/CreationDate(D:20240522141508-04'00')
/Creator<FEFF0050004400460073006800610072007000200031002E00350030002E0034003000300030002D006E00650074007300740061
006E00640061007200640020002800680074007400700073003A002F002F006700690074006800750062002E0063006F
006D002F007300740073007400650069006700650072002F005000640066005300680061007200700043006F00720065
0029>
/Producer(PDFsharp 1.50.4000-netstandard \(https://github.com/ststeiger/PdfSharpCore\))
>>
endobj
2 0 obj
<<
/Type/Catalog
/Pages 3 0 R
>>
endobj
3 0 obj
<<
/Type/Pages
/Count 1
/Kids[4 0 R]
>>
endobj
4 0 obj
<<
/Type/Page
/MediaBox[0 0 612 792]
/Parent 3 0 R
/Group
<<
/CS/DeviceRGB
/S/Transparency
>>
>>
endobj
xref
0 5
0000000000 65535 f 
0000000015 00000 n 
0000000477 00000 n 
0000000525 00000 n 
0000000580 00000 n 
trailer
<<
/ID[<FCEAE9E3BEA9864C83AA492B76687F02><FCEAE9E3BEA9864C83AA492B76687F02>]
/Info 1 0 R
/Root 2 0 R
/Size 5
>>
startxref
692
%%EOF

```

</details

After:

<details>
<summary>After</summary>

```
%PDF-1.4
%����
1 0 obj
<<
/CreationDate (D:20240523110806-04'00')
/Creator <FEFF0050004400460073006800610072007000200031002E00350030002E0034003000300030002D006E00650074007300740061
006E00640061007200640020002800680074007400700073003A002F002F006700690074006800750062002E0063006F
006D002F007300740073007400650069006700650072002F005000640066005300680061007200700043006F00720065
0029>
/Producer (PDFsharp 1.50.4000-netstandard \(https://github.com/ststeiger/PdfSharpCore\))
>>
endobj
2 0 obj
<<
/Type /Catalog
/Pages 3 0 R
>>
endobj
3 0 obj
<<
/Type /Pages
/Count 1
/Kids [4 0 R]
>>
endobj
4 0 obj
<<
/Type /Page
/MediaBox [0 0 612 792]
/Parent 3 0 R
/Group
<<
/CS /DeviceRGB
/S /Transparency
>>
>>
endobj
xref
0 5
0000000000 65535 f 
0000000015 00000 n 
0000000480 00000 n 
0000000529 00000 n 
0000000586 00000 n 
trailer
<<
/ID [<6751B1FD3ECE5F4FAA48B04D7CC83F7D><6751B1FD3ECE5F4FAA48B04D7CC83F7D>]
/Info 1 0 R
/Root 2 0 R
/Size 5
>>
startxref
702
%%EOF

```

</details>