### PR TITLE
Update SixLabors.ImageSharp package version

### DIFF
--- a/PdfSharpCore/PdfSharpCore.csproj
+++ b/PdfSharpCore/PdfSharpCore.csproj
@@ -49,7 +49,7 @@ PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally Mi
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta17" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi, 
I updated SixLabors.ImageSharp to patched version 2.1.10. Version 1.0.4 has number of known vulnerabilities: 

- https://github.com/advisories/GHSA-65x7-c272-7g7r
- https://github.com/advisories/GHSA-g85r-6x2q-45w7
- https://github.com/advisories/GHSA-5x7m-6737-26cr
- https://github.com/advisories/GHSA-63p8-c4ww-9cg7
- https://github.com/advisories/GHSA-2cmq-823j-5qj8